### PR TITLE
Issues when 'humanize-numbers' set in config

### DIFF
--- a/src/taskmanager.cpp
+++ b/src/taskmanager.cpp
@@ -207,7 +207,7 @@ void TaskManager::getOverallStats()
         args << "--keyfile" << _tarsnapKeyFile;
     if(!_tarsnapCacheDir.isEmpty())
         args << "--cachedir" << _tarsnapCacheDir;
-    args << "--print-stats";
+    args << "--print-stats" << "--no-humanize-numbers";
     overallStats->setCommand(makeTarsnapCommand(CMD_TARSNAP));
     overallStats->setArguments(args);
     connect(overallStats, SIGNAL(finished(QUuid,QVariant,int,QString))

--- a/src/taskmanager.cpp
+++ b/src/taskmanager.cpp
@@ -137,7 +137,8 @@ void TaskManager::getArchiveStats(ArchivePtr archive)
         args << "--keyfile" << _tarsnapKeyFile;
     if(!_tarsnapCacheDir.isEmpty())
         args << "--cachedir" << _tarsnapCacheDir;
-    args << "--print-stats" << "-f" << archive->name();
+    args << "--print-stats" << "--no-humanize-numbers"
+         << "-f" << archive->name();
     statsClient->setCommand(makeTarsnapCommand(CMD_TARSNAP));
     statsClient->setArguments(args);
     connect(statsClient, SIGNAL(finished(QUuid,QVariant,int,QString)), this


### PR DESCRIPTION
The regex would fail with 'humanize-numbers' set in my config file. Just add '--no-humanize-numbers' to avoid this in the two places that I found would correct the problem.