### PR TITLE
Run clang-format 3.8.0 on all source files

### DIFF
--- a/src/backuptask.cpp
+++ b/src/backuptask.cpp
@@ -16,12 +16,16 @@ BackupTask::BackupTask()
       _status(TaskStatus::Initialized)
 {
     QSettings settings;
-    setOptionPreservePaths(settings.value("tarsnap/preserve_pathnames", true).toBool());
-    setOptionTraverseMount(settings.value("tarsnap/traverse_mount", true).toBool());
-    setOptionFollowSymLinks(settings.value("tarsnap/follow_symlinks", false).toBool());
+    setOptionPreservePaths(
+        settings.value("tarsnap/preserve_pathnames", true).toBool());
+    setOptionTraverseMount(
+        settings.value("tarsnap/traverse_mount", true).toBool());
+    setOptionFollowSymLinks(
+        settings.value("tarsnap/follow_symlinks", false).toBool());
     setOptionSkipFilesSize(settings.value("app/skip_files_size", 0).toULongLong());
     setOptionSkipSystem(settings.value("app/skip_system_enabled", false).toBool());
-    setOptionSkipSystemFiles(settings.value("app/skip_system_files", "").toString());
+    setOptionSkipSystemFiles(
+        settings.value("app/skip_system_files", "").toString());
 }
 
 bool BackupTask::optionPreservePaths() const
@@ -124,7 +128,8 @@ QStringList BackupTask::getExcludesList()
                         if(entry.isFile())
                         {
                             if(quint64(entry.size()) >= _optionSkipFilesSize)
-                                skipList << QRegExp::escape(entry.absoluteFilePath());
+                                skipList
+                                    << QRegExp::escape(entry.absoluteFilePath());
                         }
                         else if(entry.isDir())
                         {

--- a/src/coreapplication.cpp
+++ b/src/coreapplication.cpp
@@ -21,7 +21,8 @@ CoreApplication::CoreApplication(int &argc, char **argv)
     qRegisterMetaType<QSqlQuery>("QSqlQuery");
     qRegisterMetaType<JobPtr>("JobPtr");
     qRegisterMetaType<QMap<QString, JobPtr>>("QMap<QString, JobPtr>");
-    qRegisterMetaType<QSystemTrayIcon::ActivationReason>("QSystemTrayIcon::ActivationReason");
+    qRegisterMetaType<QSystemTrayIcon::ActivationReason>(
+        "QSystemTrayIcon::ActivationReason");
     qRegisterMetaType<TarsnapError>("TarsnapError");
     qRegisterMetaType<LogEntry>("LogEntry");
     qRegisterMetaType<QVector<LogEntry>>("QVector<LogEntry>");
@@ -43,16 +44,25 @@ CoreApplication::~CoreApplication()
 void CoreApplication::parseArgs()
 {
     QCommandLineParser parser;
-    parser.setApplicationDescription(QLatin1String("Tarsnap GUI - Online backups for the truly lazy"));
+    parser.setApplicationDescription(
+        QLatin1String("Tarsnap GUI - Online backups for the truly lazy"));
     parser.addHelpOption();
     parser.addVersionOption();
-    QCommandLineOption jobsOption(QStringList() << "j" << "jobs",
-                                  tr("Executes all jobs sequentially that have the \'Include in scheduled backups\' option checked."
-                                     " The application runs headless and useful information is printed to standard out and error."));
-    QCommandLineOption appDataOption(QStringList() << "a" << "appdata",
-                                    tr("Use the specified app data directory."
-                                       " Useful for multiple configurations on the same machine (INI format is implied)."),
-                                    tr("directory"));
+    QCommandLineOption jobsOption(QStringList() << "j"
+                                                << "jobs",
+                                  tr("Executes all jobs sequentially that have "
+                                     "the \'Include in scheduled backups\' "
+                                     "option checked."
+                                     " The application runs headless and "
+                                     "useful information is printed to "
+                                     "standard out and error."));
+    QCommandLineOption appDataOption(QStringList() << "a"
+                                                   << "appdata",
+                                     tr("Use the specified app data directory."
+                                        " Useful for multiple configurations "
+                                        "on the same machine (INI format is "
+                                        "implied)."),
+                                     tr("directory"));
     parser.addOption(jobsOption);
     parser.addOption(appDataOption);
     parser.process(arguments());
@@ -106,8 +116,8 @@ bool CoreApplication::initialize()
     // First time init of the Store
     PersistentStore::instance();
 
-    connect(&_taskManager, &TaskManager::displayNotification,
-            &_notification, &Notification::displayNotification, QUEUED);
+    connect(&_taskManager, &TaskManager::displayNotification, &_notification,
+            &Notification::displayNotification, QUEUED);
     connect(&_taskManager, &TaskManager::message, &_journal, &Journal::log,
             QUEUED);
 
@@ -205,12 +215,12 @@ void CoreApplication::showMainWindow()
             &Notification::displayNotification, QUEUED);
     connect(_mainWindow, &MainWindow::logMessage, &_journal, &Journal::log,
             QUEUED);
-    connect(&_journal, &Journal::journal, _mainWindow,
-            &MainWindow::setJournal, QUEUED);
+    connect(&_journal, &Journal::journal, _mainWindow, &MainWindow::setJournal,
+            QUEUED);
     connect(&_journal, &Journal::logEntry, _mainWindow,
             &MainWindow::appendToJournalLog, QUEUED);
-    connect(_mainWindow, &MainWindow::clearJournal, &_journal,
-            &Journal::purge, QUEUED);
+    connect(_mainWindow, &MainWindow::clearJournal, &_journal, &Journal::purge,
+            QUEUED);
 
     QMetaObject::invokeMethod(&_taskManager, "loadArchives", QUEUED);
     QMetaObject::invokeMethod(&_taskManager, "loadJobs", QUEUED);
@@ -225,8 +235,8 @@ void CoreApplication::showMainWindow()
 
 bool CoreApplication::reinit()
 {
-    disconnect(&_taskManager, &TaskManager::displayNotification,
-               &_notification, &Notification::displayNotification);
+    disconnect(&_taskManager, &TaskManager::displayNotification, &_notification,
+               &Notification::displayNotification);
     disconnect(&_taskManager, &TaskManager::message, &_journal, &Journal::log);
 
     if(_mainWindow)

--- a/src/coreapplication.h
+++ b/src/coreapplication.h
@@ -2,8 +2,8 @@
 #define COREAPPLICATION_H
 
 #include "notification.h"
-#include "taskmanager.h"
 #include "persistentmodel/journal.h"
+#include "taskmanager.h"
 #include "widgets/mainwindow.h"
 
 #include <QApplication>
@@ -26,7 +26,7 @@ public slots:
     void showMainWindow();
 
 private:
-    MainWindow  *_mainWindow;
+    MainWindow * _mainWindow;
     Notification _notification;
     TaskManager  _taskManager;
     QThread      _managerThread;

--- a/src/debug.h
+++ b/src/debug.h
@@ -19,35 +19,134 @@
 
 #define LOG Debug::instance()
 #define ENDL "\n"
-#define DELIMITER "--------------------------------------------------------------------------------"
+#define DELIMITER                                                              \
+    "------------------------------------------------------------------------" \
+    "--------"
 
 class Debug : public QObject
 {
     Q_OBJECT
 
 public:
-    static void initialize() { qSetMessagePattern("%{if-debug}%{file}(%{line}): %{endif}%{message}"); }
-    static Debug &instance() { static Debug instance; return instance; }
+    static void initialize()
+    {
+        qSetMessagePattern("%{if-debug}%{file}(%{line}): %{endif}%{message}");
+    }
+    static Debug &instance()
+    {
+        static Debug instance;
+        return instance;
+    }
     ~Debug() {}
 
-    inline Debug& operator<<(QChar t) { WARN << t; emit message(QString(t)); return *this; }
-    inline Debug& operator<<(bool t) { WARN << t; emit message(QString(t)); return *this; }
-    inline Debug& operator<<(char t) { WARN << t; emit message(QString(t)); return *this; }
-    inline Debug& operator<<(signed short t) { WARN << t; emit message(QString::number(t)); return *this; }
-    inline Debug& operator<<(unsigned short t) { WARN << t; emit message(QString::number(t)); return *this; }
-    inline Debug& operator<<(signed int t) { WARN << t; emit message(QString::number(t)); return *this; }
-    inline Debug& operator<<(unsigned int t) { WARN << t; emit message(QString::number(t)); return *this; }
-    inline Debug& operator<<(signed long t) { WARN << t; emit message(QString::number(t)); return *this; }
-    inline Debug& operator<<(unsigned long t) { WARN << t; emit message(QString::number(t)); return *this; }
-    inline Debug& operator<<(qint64 t) { WARN << t; emit message(QString::number(t)); return *this; }
-    inline Debug& operator<<(quint64 t) { WARN << t; emit message(QString::number(t)); return *this; }
-    inline Debug& operator<<(float t) { WARN << t; emit message(QString::number(t)); return *this; }
-    inline Debug& operator<<(double t) { WARN << t; emit message(QString::number(t)); return *this; }
-    inline Debug& operator<<(const char* t) { WARN << t; emit message(QString::fromUtf8(t)); return *this; }
-    inline Debug& operator<<(const QString& t) { WARN << t; emit message(t); return *this; }
-    inline Debug& operator<<(const QStringRef& t) { WARN << t; emit message(t.toString()); return *this; }
-    inline Debug& operator<<(QLatin1String t) { WARN << t; emit message(QString(t)); return *this; }
-    inline Debug& operator<<(const QByteArray& t) { WARN << t; emit message(QString(t)); return *this; }
+    inline Debug &operator<<(QChar t)
+    {
+        WARN << t;
+        emit message(QString(t));
+        return *this;
+    }
+    inline Debug &operator<<(bool t)
+    {
+        WARN << t;
+        emit message(QString(t));
+        return *this;
+    }
+    inline Debug &operator<<(char t)
+    {
+        WARN << t;
+        emit message(QString(t));
+        return *this;
+    }
+    inline Debug &operator<<(signed short t)
+    {
+        WARN << t;
+        emit message(QString::number(t));
+        return *this;
+    }
+    inline Debug &operator<<(unsigned short t)
+    {
+        WARN << t;
+        emit message(QString::number(t));
+        return *this;
+    }
+    inline Debug &operator<<(signed int t)
+    {
+        WARN << t;
+        emit message(QString::number(t));
+        return *this;
+    }
+    inline Debug &operator<<(unsigned int t)
+    {
+        WARN << t;
+        emit message(QString::number(t));
+        return *this;
+    }
+    inline Debug &operator<<(signed long t)
+    {
+        WARN << t;
+        emit message(QString::number(t));
+        return *this;
+    }
+    inline Debug &operator<<(unsigned long t)
+    {
+        WARN << t;
+        emit message(QString::number(t));
+        return *this;
+    }
+    inline Debug &operator<<(qint64 t)
+    {
+        WARN << t;
+        emit message(QString::number(t));
+        return *this;
+    }
+    inline Debug &operator<<(quint64 t)
+    {
+        WARN << t;
+        emit message(QString::number(t));
+        return *this;
+    }
+    inline Debug &operator<<(float t)
+    {
+        WARN << t;
+        emit message(QString::number(t));
+        return *this;
+    }
+    inline Debug &operator<<(double t)
+    {
+        WARN << t;
+        emit message(QString::number(t));
+        return *this;
+    }
+    inline Debug &operator<<(const char *t)
+    {
+        WARN << t;
+        emit message(QString::fromUtf8(t));
+        return *this;
+    }
+    inline Debug &operator<<(const QString &t)
+    {
+        WARN << t;
+        emit message(t);
+        return *this;
+    }
+    inline Debug &operator<<(const QStringRef &t)
+    {
+        WARN << t;
+        emit message(t.toString());
+        return *this;
+    }
+    inline Debug &operator<<(QLatin1String t)
+    {
+        WARN << t;
+        emit message(QString(t));
+        return *this;
+    }
+    inline Debug &operator<<(const QByteArray &t)
+    {
+        WARN << t;
+        emit message(QString(t));
+        return *this;
+    }
 
 signals:
     void message(const QString message);

--- a/src/error.h
+++ b/src/error.h
@@ -1,7 +1,6 @@
 #ifndef ERROR_H
 #define ERROR_H
 
-
 enum TarsnapError
 {
     CacheError,
@@ -9,4 +8,3 @@ enum TarsnapError
 };
 
 #endif // ERROR_H
-

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -15,6 +15,7 @@ void Notification::displayNotification(QString message)
        isSystemTrayAvailable())
     {
         show();
-        showMessage(QCoreApplication::instance()->applicationName(), message.remove(QRegExp("<[^>]*>")));
+        showMessage(QCoreApplication::instance()->applicationName(),
+                    message.remove(QRegExp("<[^>]*>")));
     }
 }

--- a/src/persistentmodel/archive.cpp
+++ b/src/persistentmodel/archive.cpp
@@ -81,7 +81,7 @@ void Archive::load()
             query.value(query.record().indexOf("sizeUniqueTotal")).toULongLong();
         _sizeUniqueCompressed =
             query.value(query.record().indexOf("sizeUniqueCompressed")).toULongLong();
-        _command  = query.value(query.record().indexOf("command")).toString();
+        _command = query.value(query.record().indexOf("command")).toString();
         _contents = query.value(query.record().indexOf("contents")).toByteArray();
         _jobRef   = query.value(query.record().indexOf("jobRef")).toString();
         setObjectKey(_name);

--- a/src/persistentmodel/archive.h
+++ b/src/persistentmodel/archive.h
@@ -64,15 +64,15 @@ public slots:
     QString archiveStats();
 
 private:
-    QString     _name;
-    QDateTime   _timestamp;
-    quint64     _sizeTotal;
-    quint64     _sizeCompressed;
-    quint64     _sizeUniqueTotal;
-    quint64     _sizeUniqueCompressed;
-    QString     _command;
-    QByteArray  _contents;
-    QString     _jobRef;
+    QString    _name;
+    QDateTime  _timestamp;
+    quint64    _sizeTotal;
+    quint64    _sizeCompressed;
+    quint64    _sizeUniqueTotal;
+    quint64    _sizeUniqueCompressed;
+    QString    _command;
+    QByteArray _contents;
+    QString    _jobRef;
 };
 
 #endif // ARCHIVE_H

--- a/src/persistentmodel/job.cpp
+++ b/src/persistentmodel/job.cpp
@@ -56,8 +56,10 @@ void Job::setArchives(const QList<ArchivePtr> &archives)
 {
     _archives.clear();
     _archives = archives;
-    std::sort(_archives.begin(), _archives.end(), [](const ArchivePtr &a, const ArchivePtr &b)
-              { return (a->timestamp() > b->timestamp()); });
+    std::sort(_archives.begin(), _archives.end(),
+              [](const ArchivePtr &a, const ArchivePtr &b) {
+                  return (a->timestamp() > b->timestamp());
+              });
     foreach(ArchivePtr archive, _archives)
     {
         connect(archive.data(), &Archive::purged, this, &Job::loadArchives,
@@ -307,7 +309,7 @@ bool Job::findObjectWithKey(QString key)
     return found;
 }
 
-//void Job::loadArchives()
+// void Job::loadArchives()
 //{
 //    if(objectKey().isEmpty())
 //    {
@@ -316,7 +318,8 @@ bool Job::findObjectWithKey(QString key)
 //    }
 //    PersistentStore &store = getStore();
 //    QSqlQuery query = store.createQuery();
-//    if(!query.prepare(QLatin1String("select * from archives where jobRef = ?")))
+//    if(!query.prepare(QLatin1String("select * from archives where jobRef =
+//    ?")))
 //    {
 //        DEBUG << query.lastError().text();
 //        return;
@@ -332,7 +335,8 @@ bool Job::findObjectWithKey(QString key)
 //            archive->load();
 //            if(!archive->objectKey().isEmpty())
 //            {
-//                connect(archive.data(), SIGNAL(purged()), this, SLOT(loadArchives()), QUEUED);
+//                connect(archive.data(), SIGNAL(purged()), this,
+//                SLOT(loadArchives()), QUEUED);
 //                archives << archive;
 //            }
 //        }while(query.next());

--- a/src/persistentmodel/journal.cpp
+++ b/src/persistentmodel/journal.cpp
@@ -25,7 +25,8 @@ void Journal::load()
     {
         while(query.next())
         {
-            QDateTime timestamp = QDateTime::fromTime_t(query.value(query.record().indexOf("timestamp")).toULongLong());
+            QDateTime timestamp = QDateTime::fromTime_t(
+                query.value(query.record().indexOf("timestamp")).toULongLong());
             QString log = query.value(query.record().indexOf("log")).toString();
             _log.push_back(LogEntry{timestamp, log});
         }

--- a/src/persistentmodel/journal.h
+++ b/src/persistentmodel/journal.h
@@ -5,8 +5,8 @@
 
 #include <QObject>
 
-
-struct LogEntry {
+struct LogEntry
+{
     QDateTime timestamp;
     QString   message;
 };
@@ -23,16 +23,19 @@ signals:
     void logEntry(LogEntry log);
     void journal(QVector<LogEntry> _log);
 
-
 public slots:
     void getJournal() { emit journal(_log); }
     void log(QString message);
 
     // From PersistentObject
-    void save(){}
+    void save() {}
     void load();
     void purge();
-    bool findObjectWithKey(QString key){Q_UNUSED(key); return false;}
+    bool findObjectWithKey(QString key)
+    {
+        Q_UNUSED(key);
+        return false;
+    }
 
 private:
     QVector<LogEntry> _log;

--- a/src/persistentmodel/persistentstore.cpp
+++ b/src/persistentmodel/persistentstore.cpp
@@ -54,7 +54,8 @@ bool PersistentStore::init()
         {
             _db.close();
             DEBUG << "Invalid PersistentStore DB found. Attempting to recover.";
-            QString newName(dbUrl + "." + QString::number(QDateTime::currentMSecsSinceEpoch()));
+            QString newName(dbUrl + "." +
+                            QString::number(QDateTime::currentMSecsSinceEpoch()));
             if(!QFile::rename(dbUrl, newName))
             {
                 DEBUG << "Failed to rename current invalid PersistentStore DB. "
@@ -215,7 +216,8 @@ bool PersistentStore::upgradeVersion0()
     bool      result = false;
     QSqlQuery query(_db);
 
-    if((result = query.exec("CREATE TABLE version (version INTEGER NOT NULL);")))
+    if((result =
+            query.exec("CREATE TABLE version (version INTEGER NOT NULL);")))
         result = query.exec("INSERT INTO version VALUES (0);");
 
     if(!result)
@@ -231,7 +233,8 @@ bool PersistentStore::upgradeVersion1()
     bool      result = false;
     QSqlQuery query(_db);
 
-    if((result = query.exec("ALTER TABLE jobs ADD COLUMN optionScheduledEnabled INTEGER;")))
+    if((result = query.exec(
+            "ALTER TABLE jobs ADD COLUMN optionScheduledEnabled INTEGER;")))
         result = query.exec("UPDATE version SET version = 1;");
 
     // Handle the special case, since I started versioning DB after two app
@@ -252,9 +255,11 @@ bool PersistentStore::upgradeVersion2()
     bool      result = false;
     QSqlQuery query(_db);
 
-    if((result = query.exec("ALTER TABLE jobs ADD COLUMN optionSkipFiles INTEGER;")))
-    if((result = query.exec("ALTER TABLE jobs ADD COLUMN optionSkipFilesPatterns TEXT;")))
-        result = query.exec("UPDATE version SET version = 2;");
+    if((result =
+            query.exec("ALTER TABLE jobs ADD COLUMN optionSkipFiles INTEGER;")))
+        if((result = query.exec(
+                "ALTER TABLE jobs ADD COLUMN optionSkipFilesPatterns TEXT;")))
+            result = query.exec("UPDATE version SET version = 2;");
 
     if(!result)
     {
@@ -269,10 +274,12 @@ bool PersistentStore::upgradeVersion3()
     bool      result = false;
     QSqlQuery query(_db);
 
-    if((result = query.exec("ALTER TABLE jobs ADD COLUMN optionSkipNoDump INTEGER;")))
-    if((result = query.exec("UPDATE archives SET contents=\"\";")))
-    if((result = query.exec("CREATE TABLE journal (timestamp INTEGER NOT NULL, log TEXT);")))
-        result = query.exec("UPDATE version SET version = 3;");
+    if((result = query.exec(
+            "ALTER TABLE jobs ADD COLUMN optionSkipNoDump INTEGER;")))
+        if((result = query.exec("UPDATE archives SET contents=\"\";")))
+            if((result = query.exec("CREATE TABLE journal (timestamp INTEGER "
+                                    "NOT NULL, log TEXT);")))
+                result = query.exec("UPDATE version SET version = 3;");
 
     if(!result)
     {

--- a/src/tarsnapaccount.cpp
+++ b/src/tarsnapaccount.cpp
@@ -8,16 +8,19 @@
 #include <QSettings>
 #include <QTableWidget>
 
-#define URL_ACTIVITY "https://www.tarsnap.com/manage.cgi?address=%1&password=%2&action=activity&format=csv"
-#define URL_MACHINE_ACTIVITY "https://www.tarsnap.com/manage.cgi?address=%1&password=%2&action=subactivity&mid=%3&format=csv"
+#define URL_ACTIVITY                                                           \
+    "https://www.tarsnap.com/"                                                 \
+    "manage.cgi?address=%1&password=%2&action=activity&format=csv"
+#define URL_MACHINE_ACTIVITY                                                   \
+    "https://www.tarsnap.com/"                                                 \
+    "manage.cgi?address=%1&password=%2&action=subactivity&mid=%3&format=csv"
 
 TarsnapAccount::TarsnapAccount(QWidget *parent) : QDialog(parent), _nam(this)
 {
     _ui.setupUi(this);
     setWindowFlags((windowFlags() | Qt::CustomizeWindowHint) &
                    ~Qt::WindowMaximizeButtonHint);
-    connect(_ui.passwordLineEdit, &QLineEdit::textEdited, this, [&]()
-    {
+    connect(_ui.passwordLineEdit, &QLineEdit::textEdited, this, [&]() {
         _ui.loginButton->setEnabled(!_ui.passwordLineEdit->text().isEmpty());
     });
 }
@@ -26,19 +29,20 @@ void TarsnapAccount::getAccountInfo(bool displayActivity,
                                     bool displayMachineActivity)
 {
     QSettings settings;
-    _user      = settings.value("tarsnap/user", "").toString();
-    _machine   = settings.value("tarsnap/machine", "").toString();
+    _user    = settings.value("tarsnap/user", "").toString();
+    _machine = settings.value("tarsnap/machine", "").toString();
     if(Utils::tarsnapVersionMinimum("1.0.37"))
     {
         emit getKeyId(settings.value("tarsnap/key", "").toString());
     }
     else
     {
-        QMessageBox::warning(this, tr("Warning"),
-                             tr("You need Tarsnap CLI utils version 1.0.37 to "
-                                "be able to fetch machine activity. "
-                                "You have version %1.")
-                             .arg(settings.value("tarsnap/version", "").toString()));
+        QMessageBox::warning(
+            this, tr("Warning"),
+            tr("You need Tarsnap CLI utils version 1.0.37 to "
+               "be able to fetch machine activity. "
+               "You have version %1.")
+                .arg(settings.value("tarsnap/version", "").toString()));
     }
     if(_user.isEmpty() || _machine.isEmpty())
     {
@@ -67,10 +71,11 @@ void TarsnapAccount::getAccountInfo(bool displayActivity,
         QString machineActivity(URL_MACHINE_ACTIVITY);
         QString hexId("%1");
         hexId = hexId.arg(_machineId, 16, 16, QLatin1Char('0'));
-        machineActivity = machineActivity.arg(
-                    QString(QUrl::toPercentEncoding(_user)),
-                    QString(QUrl::toPercentEncoding(_ui.passwordLineEdit->text())),
-                    QString(QUrl::toPercentEncoding(hexId)));
+        machineActivity =
+            machineActivity.arg(QString(QUrl::toPercentEncoding(_user)),
+                                QString(QUrl::toPercentEncoding(
+                                    _ui.passwordLineEdit->text())),
+                                QString(QUrl::toPercentEncoding(hexId)));
         QNetworkReply *machineActivityReply = tarsnapRequest(machineActivity);
         connect(machineActivityReply, &QNetworkReply::finished, [=]() {
             QByteArray replyData = readReply(machineActivityReply);
@@ -177,13 +182,16 @@ QByteArray TarsnapAccount::readReply(QNetworkReply *reply, bool warn)
     QByteArray data = reply->readAll();
     if(warn && data.contains("Password is incorrect; please try again."))
     {
-        QMessageBox::warning(this, tr("Invalid password"),
+        QMessageBox::warning(
+            this, tr("Invalid password"),
             tr("Password for account %1 is incorrect; please try again.").arg(_user));
     }
-    else if(warn && data.contains("No user exists with the provided email "
-                                  "address; please try again."))
+    else if(warn &&
+            data.contains("No user exists with the provided email "
+                          "address; please try again."))
     {
-        QMessageBox::warning(this, tr("Invalid username"),
+        QMessageBox::warning(
+            this, tr("Invalid username"),
             tr("Account %1 is invalid; please try again.").arg(_user));
     }
     reply->close();

--- a/src/tarsnapclient.h
+++ b/src/tarsnapclient.h
@@ -23,7 +23,7 @@ public:
     void setArguments(const QStringList &arguments);
 
     void stop(bool kill = false);
-    void interrupt();
+    void                   interrupt();
     QProcess::ProcessState statusClient();
 
     bool waitForClient();
@@ -51,7 +51,7 @@ private slots:
 
 private:
     QVariant    _data; // caller supplied data
-    QProcess   *_process;
+    QProcess *  _process;
     QByteArray  _processOutput;
     QString     _command;
     QStringList _arguments;

--- a/src/taskmanager.cpp
+++ b/src/taskmanager.cpp
@@ -65,7 +65,8 @@ void TaskManager::registerMachine(QString user, QString password,
     if(keyFile.exists())
     {
         // existing key, just check with a tarsnap --print-stats command
-        args << "--fsck-prune" << "--keyfile" << key << "--cachedir" << cachePath;
+        args << "--fsck-prune"
+             << "--keyfile" << key << "--cachedir" << cachePath;
         registerClient->setCommand(tarsnapPath + QDir::separator() + CMD_TARSNAP);
         registerClient->setArguments(args);
     }
@@ -150,13 +151,15 @@ void TaskManager::getArchives()
                                     // man page, however Tarsnap CLI seems to
                                     // require it
         args << "--cachedir" << _tarsnapCacheDir;
-    args << "--list-archives" << "-vv";
+    args << "--list-archives"
+         << "-vv";
     listArchivesClient->setCommand(makeTarsnapCommand(CMD_TARSNAP));
     listArchivesClient->setArguments(args);
     connect(listArchivesClient, &TarsnapClient::finished, this,
             &TaskManager::getArchiveListFinished, QUEUED);
-    connect(listArchivesClient, &TarsnapClient::started, this,[&]()
-            { emit message(tr("Updating archives list from remote...")); }, QUEUED);
+    connect(listArchivesClient, &TarsnapClient::started, this,
+            [&]() { emit message(tr("Updating archives list from remote...")); },
+            QUEUED);
     queueTask(listArchivesClient);
 }
 
@@ -213,8 +216,12 @@ void TaskManager::getArchiveStats(ArchivePtr archive)
     statsClient->setData(archive->name());
     connect(statsClient, &TarsnapClient::finished, this,
             &TaskManager::getArchiveStatsFinished, QUEUED);
-    connect(statsClient, &TarsnapClient::started, this, [=]()
-            {emit message(tr("Fetching stats for archive <i>%1</i>...").arg(archive->name()));}, QUEUED);
+    connect(statsClient, &TarsnapClient::started, this,
+            [=]() {
+                emit message(tr("Fetching stats for archive <i>%1</i>...")
+                                 .arg(archive->name()));
+            },
+            QUEUED);
     queueTask(statsClient);
 }
 
@@ -238,14 +245,19 @@ void TaskManager::getArchiveContents(ArchivePtr archive)
         args << "--cachedir" << _tarsnapCacheDir;
     if(_preservePathnames)
         args << "-P";
-    args << "-t" << "-f" << archive->name();
+    args << "-t"
+         << "-f" << archive->name();
     contentsClient->setCommand(makeTarsnapCommand(CMD_TARSNAP));
     contentsClient->setArguments(args);
     contentsClient->setData(archive->name());
     connect(contentsClient, &TarsnapClient::finished, this,
             &TaskManager::getArchiveContentsFinished, QUEUED);
-    connect(contentsClient, &TarsnapClient::started, this, [=]()
-           {emit message(tr("Fetching contents for archive <i>%1</i>...").arg(archive->name()));}, QUEUED);
+    connect(contentsClient, &TarsnapClient::started, this,
+            [=]() {
+                emit message(tr("Fetching contents for archive <i>%1</i>...")
+                                 .arg(archive->name()));
+            },
+            QUEUED);
     queueTask(contentsClient);
 }
 
@@ -263,7 +275,8 @@ void TaskManager::deleteArchives(QList<ArchivePtr> archives)
         args << "--keyfile" << _tarsnapKeyFile;
     if(!_tarsnapCacheDir.isEmpty())
         args << "--cachedir" << _tarsnapCacheDir;
-    args << "--print-stats" << "-d";
+    args << "--print-stats"
+         << "-d";
     foreach(ArchivePtr archive, archives)
     {
         args << "-f" << archive->name();
@@ -273,23 +286,25 @@ void TaskManager::deleteArchives(QList<ArchivePtr> archives)
     delArchives->setData(QVariant::fromValue(archives));
     connect(delArchives, &TarsnapClient::finished, this,
             &TaskManager::deleteArchivesFinished, QUEUED);
-    connect(delArchives, &TarsnapClient::started, this, [=](QVariant data)
-    {
-        QList<ArchivePtr> archives = data.value<QList<ArchivePtr>>();
-        notifyArchivesDeleted(archives, false);
-    }, QUEUED);
+    connect(delArchives, &TarsnapClient::started, this,
+            [=](QVariant data) {
+                QList<ArchivePtr> archives = data.value<QList<ArchivePtr>>();
+                notifyArchivesDeleted(archives, false);
+            },
+            QUEUED);
     queueTask(delArchives, true);
 }
 
 void TaskManager::getOverallStats()
 {
     TarsnapClient *overallStats = new TarsnapClient();
-    QStringList args;
+    QStringList    args;
     if(!_tarsnapKeyFile.isEmpty())
         args << "--keyfile" << _tarsnapKeyFile;
     if(!_tarsnapCacheDir.isEmpty())
         args << "--cachedir" << _tarsnapCacheDir;
-    args << "--print-stats" << "--no-humanize-numbers";
+    args << "--print-stats"
+         << "--no-humanize-numbers";
     overallStats->setCommand(makeTarsnapCommand(CMD_TARSNAP));
     overallStats->setArguments(args);
     connect(overallStats, &TarsnapClient::finished, this,
@@ -300,7 +315,7 @@ void TaskManager::getOverallStats()
 void TaskManager::fsck(bool prune)
 {
     TarsnapClient *fsck = new TarsnapClient();
-    QStringList args;
+    QStringList    args;
     if(!_tarsnapKeyFile.isEmpty())
         args << "--keyfile" << _tarsnapKeyFile;
     if(!_tarsnapCacheDir.isEmpty())
@@ -311,15 +326,15 @@ void TaskManager::fsck(bool prune)
         args << "--fsck";
     fsck->setCommand(makeTarsnapCommand(CMD_TARSNAP));
     fsck->setArguments(args);
-    connect(fsck, &TarsnapClient::finished, this,
-            &TaskManager::fsckFinished, QUEUED);
+    connect(fsck, &TarsnapClient::finished, this, &TaskManager::fsckFinished,
+            QUEUED);
     queueTask(fsck, true);
 }
 
 void TaskManager::nuke()
 {
     TarsnapClient *nuke = new TarsnapClient();
-    QStringList args;
+    QStringList    args;
     if(!_tarsnapKeyFile.isEmpty())
         args << "--keyfile" << _tarsnapKeyFile;
     if(!_tarsnapCacheDir.isEmpty())
@@ -329,10 +344,10 @@ void TaskManager::nuke()
     nuke->setPassword("No Tomorrow");
     nuke->setRequiresPassword(true);
     nuke->setArguments(args);
-    connect(nuke, &TarsnapClient::finished, this,
-            &TaskManager::nukeFinished, QUEUED);
-    connect(nuke, &TarsnapClient::started, this, [=]()
-    {emit message(tr("Archives purge initiated..."));}, QUEUED);
+    connect(nuke, &TarsnapClient::finished, this, &TaskManager::nukeFinished,
+            QUEUED);
+    connect(nuke, &TarsnapClient::started, this,
+            [=]() { emit message(tr("Archives purge initiated...")); }, QUEUED);
     queueTask(nuke, true);
 }
 
@@ -347,18 +362,20 @@ void TaskManager::restoreArchive(ArchivePtr archive, ArchiveRestoreOptions optio
     _archiveMap.insert(archive->name(), archive);
 
     TarsnapClient *restore = new TarsnapClient();
-    QStringList args;
+    QStringList    args;
     if(!_tarsnapKeyFile.isEmpty())
         args << "--keyfile" << _tarsnapKeyFile;
     if(options.optionRestore)
-        args << "-x" << "-P";
+        args << "-x"
+             << "-P";
     if(options.optionRestoreDir)
-        args << "-x" << "-C" << options.path;
-    if((options.optionRestore || options.optionRestoreDir)
-       && !options.overwriteFiles)
+        args << "-x"
+             << "-C" << options.path;
+    if((options.optionRestore || options.optionRestoreDir) &&
+       !options.overwriteFiles)
         args << "-k";
-    if((options.optionRestore || options.optionRestoreDir)
-       && options.keepNewerFiles)
+    if((options.optionRestore || options.optionRestoreDir) &&
+       options.keepNewerFiles)
         args << "--keep-newer-files";
     if(options.optionDownArchive)
     {
@@ -371,8 +388,12 @@ void TaskManager::restoreArchive(ArchivePtr archive, ArchiveRestoreOptions optio
     restore->setData(archive->name());
     connect(restore, &TarsnapClient::finished, this,
             &TaskManager::restoreArchiveFinished, QUEUED);
-    connect(restore, &TarsnapClient::started, this, [=]()
-            {emit message(tr("Restoring archive <i>%1</i>...").arg(archive->name()));}, QUEUED);
+    connect(restore, &TarsnapClient::started, this,
+            [=]() {
+                emit message(
+                    tr("Restoring archive <i>%1</i>...").arg(archive->name()));
+            },
+            QUEUED);
     queueTask(restore);
 }
 
@@ -573,7 +594,8 @@ void TaskManager::getArchiveStatsFinished(QVariant data, int exitCode,
 
     if(archive && (exitCode == SUCCESS))
     {
-        emit message(tr("Fetching stats for archive <i>%1</i>...done").arg(archive->name()));
+        emit message(
+            tr("Fetching stats for archive <i>%1</i>...done").arg(archive->name()));
     }
     else
     {
@@ -599,7 +621,8 @@ void TaskManager::getArchiveContentsFinished(QVariant data, int exitCode,
 
     if(archive && (exitCode == SUCCESS))
     {
-        emit message(tr("Fetching contents for archive <i>%1</i>...done").arg(archive->name()));
+        emit message(tr("Fetching contents for archive <i>%1</i>...done")
+                         .arg(archive->name()));
     }
     else
     {
@@ -646,7 +669,7 @@ void TaskManager::deleteArchivesFinished(QVariant data, int exitCode,
     // We are only interested in the output of the last archive deleted
     QStringList lines = output.split('\n', QString::SkipEmptyParts);
     QStringList lastFive;
-    int count = lines.count();
+    int         count = lines.count();
     for(int i = 0; i < std::min(5, count); ++i)
         lastFive.prepend(lines.takeLast());
     parseGlobalStats(lastFive.join('\n'));
@@ -694,7 +717,8 @@ void TaskManager::nukeFinished(QVariant data, int exitCode, QString output)
     }
     else
     {
-        emit message(tr("Archives purging failed. Hover mouse for details."), output);
+        emit message(tr("Archives purging failed. Hover mouse for details."),
+                     output);
         parseError(output);
         return;
     }
@@ -706,12 +730,15 @@ void TaskManager::restoreArchiveFinished(QVariant data, int exitCode,
     ArchivePtr archive = _archiveMap[data.toString()];
     if(archive && (exitCode == SUCCESS))
     {
-        emit message(tr("Restoring archive <i>%1</i>...done").arg(archive->name()));
+        emit message(
+            tr("Restoring archive <i>%1</i>...done").arg(archive->name()));
     }
     else
     {
-        emit message(tr("Restoring archive <i>%1</i> failed. Hover mouse for details.")
-                     .arg(archive->name()), output);
+        emit message(
+            tr("Restoring archive <i>%1</i> failed. Hover mouse for details.")
+                .arg(archive->name()),
+            output);
         parseError(output);
         return;
     }
@@ -734,10 +761,11 @@ void TaskManager::notifyBackupTaskUpdate(QUuid uuid, const TaskStatus &status)
         break;
     case TaskStatus::Completed:
     {
-        QString msg =  tr("Backup <i>%1</i> completed. (%2 new data on Tarsnap)")
-                       .arg(backupTask->name())
-                       .arg(Utils::humanBytes(backupTask->archive()->sizeUniqueCompressed()
-                                              , useIECPrefixes));
+        QString msg = tr("Backup <i>%1</i> completed. (%2 new data on Tarsnap)")
+                          .arg(backupTask->name())
+                          .arg(Utils::humanBytes(
+                              backupTask->archive()->sizeUniqueCompressed(),
+                              useIECPrefixes));
         emit message(msg, backupTask->archive()->archiveStats());
         emit displayNotification(msg.remove(QRegExp("<[^>]*>")));
         _backupTaskMap.remove(backupTask->uuid());
@@ -749,13 +777,14 @@ void TaskManager::notifyBackupTaskUpdate(QUuid uuid, const TaskStatus &status)
     case TaskStatus::Running:
     {
         QString msg = tr("Backup <i>%1</i> is running.").arg(backupTask->name());
-        emit message(msg);
-        emit displayNotification(msg.remove(QRegExp("<[^>]*>")));
+        emit    message(msg);
+        emit    displayNotification(msg.remove(QRegExp("<[^>]*>")));
         break;
     }
     case TaskStatus::Failed:
     {
-        QString msg = tr("Backup <i>%1</i> failed: %2").arg(backupTask->name())
+        QString msg = tr("Backup <i>%1</i> failed: %2")
+                          .arg(backupTask->name())
                           .arg(backupTask->output().simplified());
         emit message(msg, backupTask->output());
         emit displayNotification(msg.remove(QRegExp("<[^>]*>")));
@@ -779,16 +808,16 @@ void TaskManager::notifyArchivesDeleted(QList<ArchivePtr> archives, bool done)
             detail.append(QString::fromLatin1(", ") + archive->name());
         }
         emit message(tr("Deleting archive <i>%1</i> and %2 more archives...%3")
-                     .arg(archives.first()->name())
-                     .arg(archives.count() - 1)
-                     .arg(done ? "done" : ""),
+                         .arg(archives.first()->name())
+                         .arg(archives.count() - 1)
+                         .arg(done ? "done" : ""),
                      detail);
     }
     else if(archives.count() == 1)
     {
         emit message(tr("Deleting archive <i>%1</i>...%2")
-                     .arg(archives.first()->name())
-                     .arg(done ? "done" : ""));
+                         .arg(archives.first()->name())
+                         .arg(done ? "done" : ""));
     }
 }
 
@@ -798,7 +827,7 @@ void TaskManager::getKeyIdFinished(QVariant data, int exitCode, QString output)
     if(exitCode == SUCCESS)
     {
         bool ok = false;
-        int id = output.toInt(&ok);
+        int  id = output.toInt(&ok);
         if(ok)
             emit keyId(key, id);
         else
@@ -873,7 +902,8 @@ void TaskManager::parseError(QString tarsnapOutput)
 {
     if(tarsnapOutput.contains("Error reading cache directory") ||
        tarsnapOutput.contains("Sequence number mismatch: Run --fsck") ||
-       tarsnapOutput.contains("Directory is not consistent with archive: Run --fsck"))
+       tarsnapOutput.contains(
+           "Directory is not consistent with archive: Run --fsck"))
     {
         emit error(TarsnapError::CacheError);
     }
@@ -948,7 +978,8 @@ void TaskManager::parseArchiveStats(QString tarsnapOutput,
     }
     else
     {
-        sizeRX.setPattern(QString("^%1\\s+(\\d+)\\s+(\\d+)$").arg(archive->name()));
+        sizeRX.setPattern(
+            QString("^%1\\s+(\\d+)\\s+(\\d+)$").arg(archive->name()));
         uniqueSizeRX.setPattern("^\\s+\\(unique data\\)\\s+(\\d+)\\s+(\\d+)$");
     }
     if(-1 != sizeRX.indexIn(sizeLine))
@@ -1029,7 +1060,7 @@ void TaskManager::deleteJob(JobPtr job, bool purgeArchives)
 
 void TaskManager::loadJobArchives()
 {
-    Job *job = qobject_cast<Job *>(sender());
+    Job *             job = qobject_cast<Job *>(sender());
     QList<ArchivePtr> archives;
     foreach(ArchivePtr archive, _archiveMap)
     {
@@ -1044,7 +1075,7 @@ void TaskManager::getTaskInfo()
     bool backupTaskRunning = false;
     if(!_runningTasks.isEmpty() && !_backupTaskMap.isEmpty())
     {
-        foreach (TarsnapClient *client, _runningTasks)
+        foreach(TarsnapClient *client, _runningTasks)
         {
             if(client && _backupTaskMap.contains(client->data().toUuid()))
             {

--- a/src/taskmanager.h
+++ b/src/taskmanager.h
@@ -1,8 +1,8 @@
 #ifndef TASKMANAGER_H
 #define TASKMANAGER_H
 
-#include "error.h"
 #include "backuptask.h"
+#include "error.h"
 #include "persistentmodel/archive.h"
 #include "persistentmodel/job.h"
 #include "tarsnapclient.h"
@@ -107,13 +107,13 @@ private:
     QString _tarsnapKeyFile;
     QMap<QUuid, BackupTaskPtr> _backupTaskMap;
     QMap<QString, ArchivePtr>  _archiveMap;
-    QList<TarsnapClient *>     _runningTasks;
-    QQueue<TarsnapClient *>    _taskQueue; // mutually exclusive tasks
-    QThreadPool               *_threadPool;
-    bool                       _aggressiveNetworking;
-    bool                       _preservePathnames;
-    bool                       _headless;
-    QMap<QString, JobPtr>      _jobMap;
+    QList<TarsnapClient *>  _runningTasks;
+    QQueue<TarsnapClient *> _taskQueue; // mutually exclusive tasks
+    QThreadPool *           _threadPool;
+    bool                    _aggressiveNetworking;
+    bool                    _preservePathnames;
+    bool                    _headless;
+    QMap<QString, JobPtr> _jobMap;
 };
 
 #endif // TASKMANAGER_H

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,8 +1,8 @@
 #include "utils.h"
 
 #include <QDebug>
-#include <QStandardPaths>
 #include <QSettings>
+#include <QStandardPaths>
 
 #include <math.h>
 
@@ -37,7 +37,8 @@ quint64 GetDirInfoTask::getDirSize(QDir dir)
             QFileInfo fileInfo = list.at(i);
             if(fileInfo.isDir())
             {
-//                qDebug() << "Traversing " << fileInfo.absoluteFilePath();
+                //                qDebug() << "Traversing " <<
+                //                fileInfo.absoluteFilePath();
                 size += getDirSize(QDir(fileInfo.absoluteFilePath()));
             }
             else
@@ -61,7 +62,8 @@ quint64 GetDirInfoTask::getDirCount(QDir dir)
             QFileInfo fileInfo = list.at(i);
             if(fileInfo.isDir())
             {
-//                qDebug() << "Traversing " << fileInfo.absoluteFilePath();
+                //                qDebug() << "Traversing " <<
+                //                fileInfo.absoluteFilePath();
                 count += getDirCount(QDir(fileInfo.absoluteFilePath()));
             }
             ++count;
@@ -127,7 +129,8 @@ QFileInfoList Utils::findKeysInPath(QString path)
 bool Utils::tarsnapVersionMinimum(const QString &minVersion)
 {
     QSettings settings;
-    QString tarsnapVersion = settings.value("tarsnap/version", "").toString();
-    QRegExp versionRx("(\\d+\\.\\d+\\.\\d+(\\.\\d+)?)");
-    return (-1 != versionRx.indexIn(tarsnapVersion)) && (versionRx.cap(0) >= minVersion);
+    QString   tarsnapVersion = settings.value("tarsnap/version", "").toString();
+    QRegExp   versionRx("(\\d+\\.\\d+\\.\\d+(\\.\\d+)?)");
+    return (-1 != versionRx.indexIn(tarsnapVersion)) &&
+           (versionRx.cap(0) >= minVersion);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -4,13 +4,15 @@
 #include <QDir>
 #include <QRunnable>
 
-#define CMD_TARSNAP         "tarsnap"
-#define CMD_TARSNAPKEYGEN   "tarsnap-keygen"
-#define CMD_TARSNAPKEYMGMT  "tarsnap-keymgmt"
+#define CMD_TARSNAP "tarsnap"
+#define CMD_TARSNAPKEYGEN "tarsnap-keygen"
+#define CMD_TARSNAPKEYMGMT "tarsnap-keymgmt"
 
-#define DEFAULT_SKIP_FILES_OSX     ".DS_Store:.fseventsd:.Spotlight-V100:._.Trashes:.Trashes"
-#define DEFAULT_SKIP_FILES_WINDOWS "$RECYCLE.BIN:System Volume Information:Thumbs.db"
-#define DEFAULT_SKIP_FILES_LINUX   ".lost+found"
+#define DEFAULT_SKIP_FILES_OSX                                                 \
+    ".DS_Store:.fseventsd:.Spotlight-V100:._.Trashes:.Trashes"
+#define DEFAULT_SKIP_FILES_WINDOWS                                             \
+    "$RECYCLE.BIN:System Volume Information:Thumbs.db"
+#define DEFAULT_SKIP_FILES_LINUX ".lost+found"
 
 #if defined Q_OS_OSX
 #define DEFAULT_SKIP_FILES DEFAULT_SKIP_FILES_OSX
@@ -22,15 +24,8 @@
 #define DEFAULT_SKIP_FILES ""
 #endif
 
-const QStringList DEFAULT_JOBS {
-    "Desktop",
-    "Documents",
-    "Pictures",
-    "Movies",
-    "Videos",
-    "Music",
-    "Work"
-};
+const QStringList DEFAULT_JOBS{"Desktop", "Documents", "Pictures", "Movies",
+                               "Videos",  "Music",     "Work"};
 
 #define QUEUED Qt::QueuedConnection
 
@@ -40,7 +35,8 @@ const QStringList DEFAULT_JOBS {
 #define APPDATA QStandardPaths::DataLocation
 #endif
 
-#define DOWNLOADS QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)
+#define DOWNLOADS                                                              \
+    QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)
 
 namespace Utils
 {
@@ -79,7 +75,7 @@ QFileInfoList findKeysInPath(QString path);
 QString validateTarsnapCache(QString path);
 
 // Verifies if the current CLI utils version is at least minVersion
-bool tarsnapVersionMinimum(const QString& minVersion);
+bool tarsnapVersionMinimum(const QString &minVersion);
 
 } // namespace Utils
 

--- a/src/widgets/archivelistitem.h
+++ b/src/widgets/archivelistitem.h
@@ -39,7 +39,7 @@ signals:
 
 private:
     Ui::ArchiveItemWidget _ui;
-    QWidget              *_widget;
+    QWidget *             _widget;
     ArchivePtr            _archive;
     bool                  _useIECPrefixes;
 };

--- a/src/widgets/archivelistwidget.cpp
+++ b/src/widgets/archivelistwidget.cpp
@@ -26,8 +26,10 @@ ArchiveListWidget::~ArchiveListWidget()
 
 void ArchiveListWidget::addArchives(QList<ArchivePtr> archives)
 {
-    std::sort(archives.begin(), archives.end(), [](const ArchivePtr &a, const ArchivePtr &b)
-              { return (a->timestamp() > b->timestamp()); });
+    std::sort(archives.begin(), archives.end(),
+              [](const ArchivePtr &a, const ArchivePtr &b) {
+                  return (a->timestamp() > b->timestamp());
+              });
     setUpdatesEnabled(false);
     clear();
     foreach(ArchivePtr archive, archives)
@@ -53,10 +55,11 @@ void ArchiveListWidget::removeItem()
     if(archiveItem)
     {
         ArchivePtr archive = archiveItem->archive();
-        auto button = QMessageBox::question(this, tr("Confirm delete"),
-                                            tr("Are you sure you want to delete "
-                                               "archive %1 (this cannot be undone)?")
-                                            .arg(archive->name()));
+        auto       button =
+            QMessageBox::question(this, tr("Confirm delete"),
+                                  tr("Are you sure you want to delete "
+                                     "archive %1 (this cannot be undone)?")
+                                      .arg(archive->name()));
         if(button == QMessageBox::Yes)
         {
             archiveItem->setDisabled();
@@ -72,7 +75,7 @@ void ArchiveListWidget::removeSelectedItems()
     if(selectedItems().isEmpty())
         return;
 
-    QList<ArchiveListItem*> selectedListItems;
+    QList<ArchiveListItem *> selectedListItems;
     // Any archives pending deletion in the selection? if so deny action
     foreach(QListWidgetItem *item, selectedItems())
     {
@@ -84,11 +87,11 @@ void ArchiveListWidget::removeSelectedItems()
     }
 
     int  selectedItemsCount = selectedItems().count();
-    auto button = QMessageBox::question(this, tr("Confirm delete"),
+    auto button             = QMessageBox::question(this, tr("Confirm delete"),
                                         tr("Are you sure you want to "
                                            "delete %1 selected archive(s) "
                                            "(this cannot be undone)?")
-                                        .arg(selectedItemsCount));
+                                            .arg(selectedItemsCount));
     if(button == QMessageBox::Yes)
     {
         // Some more deletion confirmation, if count of archives to be
@@ -98,12 +101,13 @@ void ArchiveListWidget::removeSelectedItems()
             // Inform of purge operation if all archives are to be removed
             if(selectedItemsCount == count())
             {
-                button = QMessageBox::question(this, tr("Confirm delete"),
-                                               tr("Are you sure you want to delete all of your "
-                                                  "archives?\n"
-                                                  "For your information, there's a purge action in "
-                                                  "Settings -> Advanced page that achieves the same "
-                                                  "thing but more efficiently."));
+                button = QMessageBox::question(
+                    this, tr("Confirm delete"),
+                    tr("Are you sure you want to delete all of your "
+                       "archives?\n"
+                       "For your information, there's a purge action in "
+                       "Settings -> Advanced page that achieves the same "
+                       "thing but more efficiently."));
             }
             else
             {
@@ -111,7 +115,7 @@ void ArchiveListWidget::removeSelectedItems()
                                                tr("This will permanently "
                                                   "delete the %1 selected "
                                                   "archives. Proceed?")
-                                               .arg(selectedItemsCount));
+                                                   .arg(selectedItemsCount));
             }
         }
     }
@@ -133,7 +137,8 @@ void ArchiveListWidget::inspectSelectedItem()
 {
     if(!selectedItems().isEmpty())
     {
-        ArchiveListItem *archiveItem = static_cast<ArchiveListItem *>(selectedItems().first());
+        ArchiveListItem *archiveItem =
+            static_cast<ArchiveListItem *>(selectedItems().first());
         if(archiveItem && !archiveItem->isDisabled())
             emit inspectArchive(archiveItem->archive());
     }
@@ -143,7 +148,8 @@ void ArchiveListWidget::restoreSelectedItem()
 {
     if(!selectedItems().isEmpty())
     {
-        ArchiveListItem *archiveItem = static_cast<ArchiveListItem *>(selectedItems().first());
+        ArchiveListItem *archiveItem =
+            static_cast<ArchiveListItem *>(selectedItems().first());
         if(archiveItem && !archiveItem->isDisabled())
         {
             RestoreDialog restoreDialog(archiveItem->archive(), this);
@@ -207,7 +213,8 @@ void ArchiveListWidget::disableArchives(QList<ArchivePtr> archives)
         ArchiveListItem *archiveItem = static_cast<ArchiveListItem *>(item(i));
         if(archiveItem)
         {
-            foreach (ArchivePtr archive, archives) {
+            foreach(ArchivePtr archive, archives)
+            {
                 if((archiveItem->archive()->objectKey() == archive->objectKey()))
                     archiveItem->setDisabled();
             }

--- a/src/widgets/archivewidget.cpp
+++ b/src/widgets/archivewidget.cpp
@@ -1,18 +1,16 @@
 #include "archivewidget.h"
 #include "ui_archivewidget.h"
 
-ArchiveWidget::ArchiveWidget(QWidget *parent) :
-    QWidget(parent),
-    _ui(new Ui::ArchiveWidget)
+ArchiveWidget::ArchiveWidget(QWidget *parent)
+    : QWidget(parent), _ui(new Ui::ArchiveWidget)
 {
     _ui->setupUi(this);
     QSettings settings;
     _useIECPrefixes = settings.value("app/iec_prefixes", false).toBool();
 
     connect(_ui->hideButton, &QPushButton::clicked, this, &ArchiveWidget::hide);
-    connect(_ui->archiveJobLabel, &TextLabel::clicked, [&]() {
-        emit jobClicked(_archive->jobRef());
-    });
+    connect(_ui->archiveJobLabel, &TextLabel::clicked,
+            [&]() { emit jobClicked(_archive->jobRef()); });
 }
 
 ArchiveWidget::~ArchiveWidget()
@@ -62,15 +60,13 @@ void ArchiveWidget::updateDetails()
             Utils::humanBytes(_archive->sizeTotal(), _useIECPrefixes));
         _ui->archiveSizeLabel->setToolTip(_archive->archiveStats());
         _ui->archiveUniqueDataLabel->setText(
-            Utils::humanBytes(_archive->sizeUniqueCompressed(),
-                              _useIECPrefixes));
-        _ui->archiveUniqueDataLabel->setToolTip(
-            _archive->archiveStats());
+            Utils::humanBytes(_archive->sizeUniqueCompressed(), _useIECPrefixes));
+        _ui->archiveUniqueDataLabel->setToolTip(_archive->archiveStats());
         _ui->archiveCommandLineEdit->setText(_archive->command());
         _ui->archiveCommandLineEdit->setCursorPosition(0);
         QString contents = _archive->contents();
-        _ui->archiveContentsLabel->setText(tr("Contents (%1)")
-                                           .arg(QString::number(contents.count('\n'))));
+        _ui->archiveContentsLabel->setText(
+            tr("Contents (%1)").arg(QString::number(contents.count('\n'))));
         _ui->archiveContentsPlainTextEdit->setPlainText(contents);
     }
 }

--- a/src/widgets/archivewidget.h
+++ b/src/widgets/archivewidget.h
@@ -1,12 +1,13 @@
 #ifndef ARCHIVEWIDGET_H
 #define ARCHIVEWIDGET_H
 
-#include "utils.h"
 #include "persistentmodel/archive.h"
+#include "utils.h"
 
 #include <QWidget>
 
-namespace Ui {
+namespace Ui
+{
 class ArchiveWidget;
 }
 
@@ -26,9 +27,9 @@ signals:
     void jobClicked(QString jobRef);
 
 private:
-    Ui::ArchiveWidget  *_ui;
-    bool                _useIECPrefixes;
-    ArchivePtr          _archive;
+    Ui::ArchiveWidget *_ui;
+    bool               _useIECPrefixes;
+    ArchivePtr         _archive;
 };
 
 #endif // ARCHIVEWIDGET_H

--- a/src/widgets/backuplistitem.cpp
+++ b/src/widgets/backuplistitem.cpp
@@ -57,9 +57,9 @@ void BackupListItem::setUrl(const QUrl &url)
         {
             QPixmap icon(":/icons/folder.png");
             _ui.iconLabel->setPixmap(icon);
-            QDir dir(file.absoluteFilePath());
-            QThreadPool *threadPool = QThreadPool::globalInstance();
-            Utils::GetDirInfoTask *task = new Utils::GetDirInfoTask(dir);
+            QDir                   dir(file.absoluteFilePath());
+            QThreadPool *          threadPool = QThreadPool::globalInstance();
+            Utils::GetDirInfoTask *task       = new Utils::GetDirInfoTask(dir);
             task->setAutoDelete(true);
             connect(task, &Utils::GetDirInfoTask::result, this,
                     &BackupListItem::updateDirDetail, QUEUED);

--- a/src/widgets/backuplistitem.h
+++ b/src/widgets/backuplistitem.h
@@ -41,7 +41,7 @@ public slots:
 
 private:
     Ui::BackupItemWidget _ui;
-    QWidget             *_widget;
+    QWidget *            _widget;
     QUrl                 _url;
     quint64              _count;
     quint64              _size;

--- a/src/widgets/backuplistwidget.cpp
+++ b/src/widgets/backuplistwidget.cpp
@@ -97,7 +97,7 @@ void BackupListWidget::recomputeListTotals()
         if(backupItem && (backupItem->count() != 0))
         {
             items += backupItem->count();
-            size  += backupItem->size();
+            size += backupItem->size();
         }
     }
     emit itemTotals(items, size);

--- a/src/widgets/filepicker.cpp
+++ b/src/widgets/filepicker.cpp
@@ -12,12 +12,12 @@ FilePicker::FilePicker(QWidget *parent)
     _ui->optionsContainer->hide();
 
     _model.setRootPath(QDir::rootPath());
-//    _model.setNameFilterDisables(false);
+    //    _model.setNameFilterDisables(false);
     _ui->treeView->setModel(&_model);
     _ui->treeView->installEventFilter(this);
     QSettings settings;
-    setCurrentPath(settings.value("app/file_browse_last",
-                                  QDir::homePath()).toString());
+    setCurrentPath(
+        settings.value("app/file_browse_last", QDir::homePath()).toString());
     _completer.setModel(&_model);
     _completer.setCompletionMode(QCompleter::InlineCompletion);
     _completer.setCaseSensitivity(Qt::CaseSensitive);
@@ -61,7 +61,7 @@ FilePicker::FilePicker(QWidget *parent)
             _ui->treeView->setFocus();
     });
     connect(_ui->homeButton, &QPushButton::clicked,
-            [&](){setCurrentPath(QDir::homePath());});
+            [&]() { setCurrentPath(QDir::homePath()); });
 }
 
 FilePicker::~FilePicker()
@@ -74,13 +74,13 @@ void FilePicker::reset()
     _model.reset();
     _ui->treeView->reset();
     QSettings settings;
-    setCurrentPath(settings.value("app/file_browse_last",
-                                  QDir::homePath()).toString());
+    setCurrentPath(
+        settings.value("app/file_browse_last", QDir::homePath()).toString());
 }
 
 QList<QUrl> FilePicker::getSelectedUrls()
 {
-    QList<QUrl> urls;
+    QList<QUrl>                  urls;
     QList<QPersistentModelIndex> indexList = _model.checkedIndexes();
     foreach(QPersistentModelIndex index, indexList)
         urls << QUrl::fromUserInput(_model.filePath(index));
@@ -124,7 +124,7 @@ bool FilePicker::eventFilter(QObject *obj, QEvent *event)
 {
     if((obj == _ui->treeView) && (event->type() == QEvent::FocusOut))
     {
-        emit focusLost();
+        emit      focusLost();
         QSettings settings;
         settings.setValue("app/file_browse_last",
                           _model.filePath(_ui->treeView->currentIndex()));

--- a/src/widgets/filepicker.h
+++ b/src/widgets/filepicker.h
@@ -23,7 +23,7 @@ public:
 
     void        reset();
     QList<QUrl> getSelectedUrls();
-    void        setSelectedUrls(const QList<QUrl> &urls);
+    void setSelectedUrls(const QList<QUrl> &urls);
 
 public slots:
     void updateFilter(QString filter);
@@ -38,7 +38,7 @@ protected:
     bool eventFilter(QObject *obj, QEvent *event);
 
 private:
-    Ui::FilePicker       *_ui;
+    Ui::FilePicker *      _ui;
     CustomFileSystemModel _model;
     QCompleter            _completer;
 };

--- a/src/widgets/filepickerdialog.cpp
+++ b/src/widgets/filepickerdialog.cpp
@@ -5,9 +5,9 @@ FilePickerDialog::FilePickerDialog(QWidget *parent)
     : QDialog(parent), _ui(new Ui::FilePickerDialog)
 {
     _ui->setupUi(this);
-    connect(_ui->filePickerWidget, &FilePicker::selectionChanged, [&]()
-    {
-        _ui->selectButton->setEnabled(!_ui->filePickerWidget->getSelectedUrls().isEmpty());
+    connect(_ui->filePickerWidget, &FilePicker::selectionChanged, [&]() {
+        _ui->selectButton->setEnabled(
+            !_ui->filePickerWidget->getSelectedUrls().isEmpty());
     });
     connect(_ui->selectButton, &QPushButton::clicked, this,
             &FilePickerDialog::accept);

--- a/src/widgets/joblistitem.cpp
+++ b/src/widgets/joblistitem.cpp
@@ -42,11 +42,12 @@ void JobListItem::setJob(const JobPtr &job)
     if(_job->archives().isEmpty())
         _ui.lastBackupLabel->setText(tr("No backup done yet"));
     else
-        _ui.lastBackupLabel->setText(
-            _job->archives().first()->timestamp().toString(Qt::DefaultLocaleLongDate));
+        _ui.lastBackupLabel->setText(_job->archives().first()->timestamp().toString(
+            Qt::DefaultLocaleLongDate));
 
     QString detail;
-    QString str = _job->archives().count() == 1 ? tr("archive") : tr("archives");
+    QString str =
+        _job->archives().count() == 1 ? tr("archive") : tr("archives");
     detail.append(tr("%1 %2 totaling ").arg(_job->archives().count()).arg(str));
     quint64 totalSize = 0;
     foreach(ArchivePtr archive, _job->archives())

--- a/src/widgets/joblistitem.h
+++ b/src/widgets/joblistitem.h
@@ -36,7 +36,7 @@ public slots:
 
 private:
     Ui::JobItemWidget _ui;
-    QWidget          *_widget;
+    QWidget *         _widget;
     JobPtr            _job;
     bool              _useIECPrefixes;
 };

--- a/src/widgets/joblistwidget.cpp
+++ b/src/widgets/joblistwidget.cpp
@@ -125,7 +125,7 @@ void JobListWidget::execDeleteJob(JobListItem *jobItem)
     if(jobItem)
     {
         bool   purgeArchives = false;
-        JobPtr job     = jobItem->job();
+        JobPtr job           = jobItem->job();
         auto   confirm =
             QMessageBox::question(this, tr("Confirm action"),
                                   tr("Are you sure you want to delete job "
@@ -180,7 +180,8 @@ void JobListWidget::addJob(JobPtr job)
 void JobListWidget::inspectSelectedItem()
 {
     if(!selectedItems().isEmpty())
-        emit displayJobDetails(static_cast<JobListItem *>(selectedItems().first())->job());
+        emit displayJobDetails(
+            static_cast<JobListItem *>(selectedItems().first())->job());
 }
 
 void JobListWidget::restoreSelectedItem()

--- a/src/widgets/jobwidget.cpp
+++ b/src/widgets/jobwidget.cpp
@@ -22,11 +22,11 @@ JobWidget::JobWidget(QWidget *parent)
         else
             save();
     });
-//    connect(_ui->jobTreeWidget, &FilePicker::focusLost,
-//            [&](){
-//                    if(!_job->objectKey().isEmpty())
-//                        save();
-//            });
+    //    connect(_ui->jobTreeWidget, &FilePicker::focusLost,
+    //            [&](){
+    //                    if(!_job->objectKey().isEmpty())
+    //                        save();
+    //            });
 
     connect(_ui->includeScheduledCheckBox, &QCheckBox::toggled, this,
             &JobWidget::save);
@@ -53,11 +53,12 @@ JobWidget::JobWidget(QWidget *parent)
             &JobWidget::deleteJobArchives);
     connect(_ui->skipFilesDefaultsButton, &QPushButton::clicked, [&]() {
         QSettings settings;
-        _ui->skipFilesLineEdit->setText(settings.value("app/skip_system_files",
-                                                       DEFAULT_SKIP_FILES).toString());
+        _ui->skipFilesLineEdit->setText(
+            settings.value("app/skip_system_files", DEFAULT_SKIP_FILES).toString());
     });
-    connect(_ui->archiveListWidget, &ArchiveListWidget::customContextMenuRequested,
-            this, &JobWidget::showArchiveListMenu);
+    connect(_ui->archiveListWidget,
+            &ArchiveListWidget::customContextMenuRequested, this,
+            &JobWidget::showArchiveListMenu);
     connect(_ui->actionDelete, &QAction::triggered, _ui->archiveListWidget,
             &ArchiveListWidget::removeSelectedItems);
     connect(_ui->actionRestore, &QAction::triggered, _ui->archiveListWidget,
@@ -130,7 +131,8 @@ void JobWidget::save()
     {
         DEBUG << "SAVE JOB";
         _job->setUrls(_ui->jobTreeWidget->getSelectedUrls());
-        _job->setOptionScheduledEnabled(_ui->includeScheduledCheckBox->isChecked());
+        _job->setOptionScheduledEnabled(
+            _ui->includeScheduledCheckBox->isChecked());
         _job->setOptionPreservePaths(_ui->preservePathsCheckBox->isChecked());
         _job->setOptionTraverseMount(_ui->traverseMountCheckBox->isChecked());
         _job->setOptionFollowSymLinks(_ui->followSymLinksCheckBox->isChecked());
@@ -149,7 +151,8 @@ void JobWidget::saveNew()
         DEBUG << "SAVE NEW JOB";
         _job->setName(_ui->jobNameLineEdit->text());
         _job->setUrls(_ui->jobTreeWidget->getSelectedUrls());
-        _job->setOptionScheduledEnabled(_ui->includeScheduledCheckBox->isChecked());
+        _job->setOptionScheduledEnabled(
+            _ui->includeScheduledCheckBox->isChecked());
         _job->setOptionPreservePaths(_ui->preservePathsCheckBox->isChecked());
         _job->setOptionTraverseMount(_ui->traverseMountCheckBox->isChecked());
         _job->setOptionFollowSymLinks(_ui->followSymLinksCheckBox->isChecked());
@@ -206,7 +209,7 @@ bool JobWidget::canSaveNew()
 void JobWidget::showArchiveListMenu(const QPoint &pos)
 {
     QPoint globalPos = _ui->archiveListWidget->viewport()->mapToGlobal(pos);
-    QMenu archiveListMenu(_ui->archiveListWidget);
+    QMenu  archiveListMenu(_ui->archiveListWidget);
     if(!_ui->archiveListWidget->selectedItems().isEmpty())
     {
         if(_ui->archiveListWidget->selectedItems().count() == 1)

--- a/src/widgets/jobwidget.h
+++ b/src/widgets/jobwidget.h
@@ -37,7 +37,7 @@ protected slots:
     void updateDetails();
     void restoreLatestArchive();
     bool canSaveNew();
-    void showArchiveListMenu(const QPoint& pos);
+    void showArchiveListMenu(const QPoint &pos);
 
 private:
     Ui::JobWidget *_ui;

--- a/src/widgets/mainwindow.cpp
+++ b/src/widgets/mainwindow.cpp
@@ -32,8 +32,8 @@ MainWindow::MainWindow(QWidget *parent)
       _purgeCountdownWindow(this),
       _tarsnapAccount(this)
 {
-    connect(&Debug::instance(), &Debug::message, this, [&](const QString &msg)
-            {_ui->consoleLog->appendPlainText(msg);});
+    connect(&Debug::instance(), &Debug::message, this,
+            [&](const QString &msg) { _ui->consoleLog->appendPlainText(msg); });
     qApp->setAttribute(Qt::AA_UseHighDpiPixmaps);
     _ui->setupUi(this);
     _ui->backupListWidget->setAttribute(Qt::WA_MacShowFocusRect, false);
@@ -51,10 +51,12 @@ MainWindow::MainWindow(QWidget *parent)
     aboutUi.setupUi(&_aboutWindow);
     aboutUi.versionLabel->setText(tr("version ") +
                                   QCoreApplication::applicationVersion());
-    _aboutWindow.setWindowFlags((_aboutWindow.windowFlags() |
-                                 Qt::CustomizeWindowHint) & ~Qt::WindowMaximizeButtonHint);
+    _aboutWindow.setWindowFlags(
+        (_aboutWindow.windowFlags() | Qt::CustomizeWindowHint) &
+        ~Qt::WindowMaximizeButtonHint);
     connect(aboutUi.checkUpdateButton, &QPushButton::clicked, []() {
-        QDesktopServices::openUrl(QUrl("https://github.com/Tarsnap/tarsnap-gui/releases"));
+        QDesktopServices::openUrl(
+            QUrl("https://github.com/Tarsnap/tarsnap-gui/releases"));
     });
 
     QMenuBar menuBar;
@@ -85,7 +87,8 @@ MainWindow::MainWindow(QWidget *parent)
 
     // Purge widget setup
     _purgeCountdownWindow.setIcon(QMessageBox::Critical);
-    _purgeCountdownWindow.setWindowTitle(tr("Deleting all archives: press Cancel to abort"));
+    _purgeCountdownWindow.setWindowTitle(
+        tr("Deleting all archives: press Cancel to abort"));
     _purgeCountdownWindow.setStandardButtons(QMessageBox::Cancel);
     connect(&_purgeTimer, &QTimer::timeout, this, &MainWindow::purgeTimerFired);
     // --
@@ -106,7 +109,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(_ui->actionRefreshAccount, &QAction::triggered, this,
             &MainWindow::getOverallStats);
     connect(_ui->actionRefreshAccount, &QAction::triggered, this,
-            [&](){_tarsnapAccount.getAccountInfo();});
+            [&]() { _tarsnapAccount.getAccountInfo(); });
     this->addAction(_ui->actionGoBackup);
     this->addAction(_ui->actionGoBrowse);
     this->addAction(_ui->actionGoJobs);
@@ -200,18 +203,16 @@ MainWindow::MainWindow(QWidget *parent)
     connect(_ui->clearJournalButton, &QPushButton::clicked, this,
             &MainWindow::clearJournalClicked);
 
-    connect(&_tarsnapAccount, &TarsnapAccount::getKeyId, this, &MainWindow::getKeyId);
+    connect(&_tarsnapAccount, &TarsnapAccount::getKeyId, this,
+            &MainWindow::getKeyId);
     connect(_ui->updateAccountButton, &QPushButton::clicked,
             _ui->actionRefreshAccount, &QAction::trigger);
-    connect(&_tarsnapAccount, SIGNAL(lastMachineActivity(QStringList)), this, SLOT(updateLastMachineActivity(QStringList)));
+    connect(&_tarsnapAccount, SIGNAL(lastMachineActivity(QStringList)), this,
+            SLOT(updateLastMachineActivity(QStringList)));
     connect(_ui->accountActivityShowButton, &QPushButton::clicked,
-    [&]() {
-        _tarsnapAccount.getAccountInfo(true, false);
-    });
+            [&]() { _tarsnapAccount.getAccountInfo(true, false); });
     connect(_ui->machineActivityShowButton, &QPushButton::clicked,
-    [&]() {
-        _tarsnapAccount.getAccountInfo(false, true);
-    });
+            [&]() { _tarsnapAccount.getAccountInfo(false, true); });
 
     // Archives
     _ui->archiveListWidget->addAction(_ui->actionRefresh);
@@ -229,10 +230,11 @@ MainWindow::MainWindow(QWidget *parent)
     connect(_ui->archiveListWidget, &ArchiveListWidget::displayJobDetails,
             _ui->jobListWidget, &JobListWidget::selectJobByRef);
     connect(_ui->archiveDetailsWidget, &ArchiveWidget::jobClicked,
-            [&](QString jobRef){ _ui->jobListWidget->selectJobByRef(jobRef); });
+            [&](QString jobRef) { _ui->jobListWidget->selectJobByRef(jobRef); });
 
-    connect(_ui->archiveListWidget, &ArchiveListWidget::customContextMenuRequested,
-            this, &MainWindow::showArchiveListMenu);
+    connect(_ui->archiveListWidget,
+            &ArchiveListWidget::customContextMenuRequested, this,
+            &MainWindow::showArchiveListMenu);
     connect(_ui->actionRefresh, &QAction::triggered, this,
             &MainWindow::getArchives);
     connect(_ui->actionDelete, &QAction::triggered, _ui->archiveListWidget,
@@ -261,8 +263,8 @@ MainWindow::MainWindow(QWidget *parent)
             &MainWindow::restoreArchive);
     connect(_ui->jobDetailsWidget, &JobWidget::deleteJobArchives, this,
             &MainWindow::deleteArchives);
-    connect(_ui->jobDetailsWidget, &JobWidget::deleteJobArchives, _ui->archiveListWidget,
-            &ArchiveListWidget::disableArchives);
+    connect(_ui->jobDetailsWidget, &JobWidget::deleteJobArchives,
+            _ui->archiveListWidget, &ArchiveListWidget::disableArchives);
     connect(_ui->jobDetailsWidget, &JobWidget::enableSave, _ui->addJobButton,
             &QToolButton::setEnabled);
     connect(_ui->jobListWidget, &JobListWidget::displayJobDetails, this,
@@ -334,7 +336,8 @@ MainWindow::MainWindow(QWidget *parent)
         updateStatusMessage(tr("Job <i>%1</i> added.").arg(job->name()));
     });
     connect(_ui->statusBarLabel, &TextLabel::clicked, [&]() {
-        _ui->expandJournalButton->setChecked(!_ui->expandJournalButton->isChecked());
+        _ui->expandJournalButton->setChecked(
+            !_ui->expandJournalButton->isChecked());
     });
     connect(_ui->simulationCheckBox, &QCheckBox::stateChanged, [&](int state) {
         if(state == Qt::Unchecked)
@@ -348,20 +351,22 @@ MainWindow::MainWindow(QWidget *parent)
         }
     });
     connect(_ui->repairCacheButton, &QPushButton::clicked, this,
-            [&](){ emit repairCache(true); });
+            [&]() { emit repairCache(true); });
     connect(_ui->skipSystemDefaultsButton, &QPushButton::clicked,
             [&]() { _ui->skipSystemLineEdit->setText(DEFAULT_SKIP_FILES); });
-    connect(_ui->jobListWidget, &JobListWidget::deleteJob, this, [&](JobPtr job, bool purgeArchives) {
-        if(_ui->jobDetailsWidget->job() == job)
-            hideJobDetails();
-        if(purgeArchives)
-            _ui->archiveListWidget->disableArchives(job->archives());
+    connect(_ui->jobListWidget, &JobListWidget::deleteJob, this,
+            [&](JobPtr job, bool purgeArchives) {
+                if(_ui->jobDetailsWidget->job() == job)
+                    hideJobDetails();
+                if(purgeArchives)
+                    _ui->archiveListWidget->disableArchives(job->archives());
+            });
+    connect(_ui->iecPrefixesCheckBox, &QCheckBox::toggled, this, [&]() {
+        QMessageBox::information(this, QApplication::applicationName(),
+                                 tr("The new size notation will take effect on "
+                                    "application restart."));
     });
-    connect(_ui->iecPrefixesCheckBox, &QCheckBox::toggled, this, [&]()
-    {QMessageBox::information(this, QApplication::applicationName(),
-                              tr("The new size notation will take effect on application restart."));});
-    connect(_ui->dismissButton, &QPushButton::clicked, [&]()
-    {
+    connect(_ui->dismissButton, &QPushButton::clicked, [&]() {
         QSettings settings;
         settings.setValue("app/defaultjobs_dismissed", true);
         _ui->defaultJobs->hide();
@@ -404,7 +409,8 @@ void MainWindow::loadSettings()
     }
 
     _ui->machineActivity->setText(
-        settings.value("tarsnap/machine_activity", tr("click update button")).toString());
+        settings.value("tarsnap/machine_activity", tr("click update button"))
+            .toString());
     _ui->accountUserLineEdit->setText(
         settings.value("tarsnap/user", "").toString());
     _ui->accountMachineKeyLineEdit->setText(
@@ -492,13 +498,13 @@ void MainWindow::keyReleaseEvent(QKeyEvent *event)
     }
 }
 
-//void MainWindow::mousePressEvent(QMouseEvent *event)
+// void MainWindow::mousePressEvent(QMouseEvent *event)
 //{
 //    if(event->buttons() & Qt::LeftButton)
 //        _windowDragPos = event->pos();
 //}
 
-//void MainWindow::mouseMoveEvent(QMouseEvent *event)
+// void MainWindow::mouseMoveEvent(QMouseEvent *event)
 //{
 //    if(event->buttons() & Qt::LeftButton)
 //    {
@@ -508,7 +514,7 @@ void MainWindow::keyReleaseEvent(QKeyEvent *event)
 //    }
 //}
 
-//void MainWindow::mouseDoubleClickEvent(QMouseEvent *event)
+// void MainWindow::mouseDoubleClickEvent(QMouseEvent *event)
 //{
 //    Q_UNUSED(event);
 //    if(isMaximized())
@@ -543,10 +549,10 @@ void MainWindow::updateSettingsSummary(quint64 sizeTotal, quint64 sizeCompressed
     _ui->accountActualSizeLabel->setText(
         Utils::humanBytes(sizeUniqueCompressed, _useIECPrefixes));
     _ui->accountActualSizeLabel->setToolTip(tooltip);
-    quint64 storageSaved = sizeTotal >= sizeUniqueCompressed ?
-                           sizeTotal - sizeUniqueCompressed : 0;
-    _ui->accountStorageSavedLabel->setText(Utils::humanBytes(storageSaved,
-                                                             _useIECPrefixes));
+    quint64 storageSaved =
+        sizeTotal >= sizeUniqueCompressed ? sizeTotal - sizeUniqueCompressed : 0;
+    _ui->accountStorageSavedLabel->setText(
+        Utils::humanBytes(storageSaved, _useIECPrefixes));
     _ui->accountStorageSavedLabel->setToolTip(tooltip);
     _ui->accountArchivesCountLabel->setText(QString::number(archiveCount));
 }
@@ -578,9 +584,11 @@ void MainWindow::updateBackupItemTotals(quint64 count, quint64 size)
 {
     if(count != 0)
     {
-        _ui->backupDetailLabel->setText(tr("%1 %2 (%3)").arg(count)
-                                        .arg(count == 1 ? "item" : "items")
-                                        .arg(Utils::humanBytes(size, _useIECPrefixes)));
+        _ui->backupDetailLabel->setText(
+            tr("%1 %2 (%3)")
+                .arg(count)
+                .arg(count == 1 ? "item" : "items")
+                .arg(Utils::humanBytes(size, _useIECPrefixes)));
         if(!_ui->backupNameLineEdit->text().isEmpty())
             _ui->backupButton->setEnabled(true);
     }
@@ -659,26 +667,33 @@ void MainWindow::commitSettings()
 {
     DEBUG << "COMMIT SETTINGS";
     QSettings settings;
-    settings.setValue("tarsnap/path",    _ui->tarsnapPathLineEdit->text());
+    settings.setValue("tarsnap/path", _ui->tarsnapPathLineEdit->text());
     settings.setValue("tarsnap/version", _tarsnapVersion);
-    settings.setValue("tarsnap/cache",   _ui->tarsnapCacheLineEdit->text());
-    settings.setValue("tarsnap/key",     _ui->accountMachineKeyLineEdit->text());
+    settings.setValue("tarsnap/cache", _ui->tarsnapCacheLineEdit->text());
+    settings.setValue("tarsnap/key", _ui->accountMachineKeyLineEdit->text());
     settings.setValue("tarsnap/machine", _ui->accountMachineLineEdit->text());
-    settings.setValue("tarsnap/user",    _ui->accountUserLineEdit->text());
-    settings.setValue("tarsnap/aggressive_networking", _ui->aggressiveNetworkingCheckBox->isChecked());
-    settings.setValue("tarsnap/preserve_pathnames", _ui->preservePathsCheckBox->isChecked());
-    settings.setValue("tarsnap/traverse_mount", _ui->traverseMountCheckBox->isChecked());
-    settings.setValue("tarsnap/follow_symlinks", _ui->followSymLinksCheckBox->isChecked());
-    settings.setValue("tarsnap/no_default_config", _ui->ignoreConfigCheckBox->isChecked());
+    settings.setValue("tarsnap/user", _ui->accountUserLineEdit->text());
+    settings.setValue("tarsnap/aggressive_networking",
+                      _ui->aggressiveNetworkingCheckBox->isChecked());
+    settings.setValue("tarsnap/preserve_pathnames",
+                      _ui->preservePathsCheckBox->isChecked());
+    settings.setValue("tarsnap/traverse_mount",
+                      _ui->traverseMountCheckBox->isChecked());
+    settings.setValue("tarsnap/follow_symlinks",
+                      _ui->followSymLinksCheckBox->isChecked());
+    settings.setValue("tarsnap/no_default_config",
+                      _ui->ignoreConfigCheckBox->isChecked());
     settings.setValue("tarsnap/dry_run", _ui->simulationCheckBox->isChecked());
     settings.setValue("app/iec_prefixes", _ui->iecPrefixesCheckBox->isChecked());
     settings.setValue("app/skip_files_size", _ui->skipFilesSizeSpinBox->value());
-    settings.setValue("app/skip_system_enabled", _ui->skipSystemJunkCheckBox->isChecked());
+    settings.setValue("app/skip_system_enabled",
+                      _ui->skipSystemJunkCheckBox->isChecked());
     settings.setValue("app/skip_system_files", _ui->skipSystemLineEdit->text());
     settings.setValue("app/skip_nodump", _ui->skipNoDumpCheckBox->isChecked());
     settings.setValue("app/downloads_dir", _ui->downloadsDirLineEdit->text());
     settings.setValue("app/app_data", _ui->appDataDirLineEdit->text());
-    settings.setValue("app/notifications", _ui->notificationsCheckBox->isChecked());
+    settings.setValue("app/notifications",
+                      _ui->notificationsCheckBox->isChecked());
     settings.sync();
     emit settingsChanged();
 }
@@ -688,9 +703,11 @@ void MainWindow::validateMachineKeyPath()
     QFileInfo machineKeyFile(_ui->accountMachineKeyLineEdit->text());
     if(machineKeyFile.exists() && machineKeyFile.isFile() &&
        machineKeyFile.isReadable())
-        _ui->accountMachineKeyLineEdit->setStyleSheet("QLineEdit {color: black;}");
+        _ui->accountMachineKeyLineEdit->setStyleSheet(
+            "QLineEdit {color: black;}");
     else
-        _ui->accountMachineKeyLineEdit->setStyleSheet("QLineEdit {color: red;}");
+        _ui->accountMachineKeyLineEdit->setStyleSheet(
+            "QLineEdit {color: red;}");
 }
 
 void MainWindow::validateTarsnapPath()
@@ -749,7 +766,9 @@ void MainWindow::appendToJournalLog(LogEntry log)
     QTextBlockFormat bf;
     bf.setBackground(QBrush(bgcolor));
     cursor.mergeBlockFormat(bf);
-    cursor.insertText(QString("[%1] %2").arg(log.timestamp.toString(Qt::DefaultLocaleShortDate)).arg(log.message));
+    cursor.insertText(QString("[%1] %2")
+                          .arg(log.timestamp.toString(Qt::DefaultLocaleShortDate))
+                          .arg(log.message));
     _ui->journalLog->moveCursor(QTextCursor::End);
     _ui->journalLog->ensureCursorVisible();
 }
@@ -882,8 +901,10 @@ void MainWindow::expandJournalButtonToggled(bool checked)
 
 void MainWindow::downloadsDirBrowseButtonClicked()
 {
-    QString downDir = QFileDialog::getExistingDirectory(this,
-                      tr("Browse for downloads directory"), DOWNLOADS);
+    QString downDir =
+        QFileDialog::getExistingDirectory(this,
+                                          tr("Browse for downloads directory"),
+                                          DOWNLOADS);
     if(!downDir.isEmpty())
     {
         _ui->downloadsDirLineEdit->setText(downDir);
@@ -933,7 +954,8 @@ void MainWindow::addJobClicked()
     }
 }
 
-void MainWindow::displayStopTasks(bool backupTaskRunning, int runningTasks, int queuedTasks)
+void MainWindow::displayStopTasks(bool backupTaskRunning, int runningTasks,
+                                  int queuedTasks)
 {
     if(!runningTasks && !queuedTasks)
     {
@@ -948,13 +970,16 @@ void MainWindow::displayStopTasks(bool backupTaskRunning, int runningTasks, int 
     msgBox.setInformativeText(tr("What do you want to do?"));
     QPushButton *interruptBackup = nullptr;
     if(backupTaskRunning)
-        interruptBackup = msgBox.addButton(tr("Interrupt backup"), QMessageBox::ActionRole);
+        interruptBackup =
+            msgBox.addButton(tr("Interrupt backup"), QMessageBox::ActionRole);
     QPushButton *stopRunning = nullptr;
     if(runningTasks)
-        stopRunning = msgBox.addButton(tr("Stop running"), QMessageBox::ActionRole);
+        stopRunning =
+            msgBox.addButton(tr("Stop running"), QMessageBox::ActionRole);
     QPushButton *stopQueued = nullptr;
     if(queuedTasks)
-        stopQueued = msgBox.addButton(tr("Cancel queued"), QMessageBox::ActionRole);
+        stopQueued =
+            msgBox.addButton(tr("Cancel queued"), QMessageBox::ActionRole);
     QPushButton *stopAll = nullptr;
     if(runningTasks && queuedTasks)
         stopAll = msgBox.addButton(tr("Stop all"), QMessageBox::ActionRole);
@@ -989,11 +1014,12 @@ void MainWindow::tarsnapError(TarsnapError error)
     {
     case TarsnapError::CacheError:
     {
-        auto confirm = QMessageBox::critical(this, tr("Tarsnap error"),
-                                             tr("The tarsnap cache directory is"
-                                                " either missing or is broken."
-                                                " Run tarsnap fsck to fix this?\n"),
-                                             QMessageBox::Yes | QMessageBox::No);
+        auto confirm =
+            QMessageBox::critical(this, tr("Tarsnap error"),
+                                  tr("The tarsnap cache directory is"
+                                     " either missing or is broken."
+                                     " Run tarsnap fsck to fix this?\n"),
+                                  QMessageBox::Yes | QMessageBox::No);
         if(confirm == QMessageBox::Yes)
             emit repairCache(false);
         break;
@@ -1023,16 +1049,18 @@ void MainWindow::updateLastMachineActivity(QStringList activityFields)
     QSettings settings;
     settings.setValue("tarsnap/machine_activity", activityFields.join(' '));
     _ui->machineActivity->setText(activityFields.join(' '));
-    _ui->machineActivity->resize(_ui->machineActivity->fontMetrics()
-                                       .width(_ui->machineActivity->text()) / 2,
+    _ui->machineActivity->resize(_ui->machineActivity->fontMetrics().width(
+                                     _ui->machineActivity->text()) /
+                                     2,
                                  _ui->machineActivity->sizeHint().height());
 }
 
 void MainWindow::clearJournalClicked()
 {
-    auto confirm = QMessageBox::question(this, tr("Confirm action"),
-                                     tr("Clear journal log? All entries will "
-                                        "be deleted forever."));
+    auto confirm =
+        QMessageBox::question(this, tr("Confirm action"),
+                              tr("Clear journal log? All entries will "
+                                 "be deleted forever."));
     if(confirm == QMessageBox::Yes)
         emit clearJournal();
 }
@@ -1040,7 +1068,7 @@ void MainWindow::clearJournalClicked()
 void MainWindow::showArchiveListMenu(const QPoint &pos)
 {
     QPoint globalPos = _ui->archiveListWidget->viewport()->mapToGlobal(pos);
-    QMenu archiveListMenu(_ui->archiveListWidget);
+    QMenu  archiveListMenu(_ui->archiveListWidget);
     archiveListMenu.addAction(_ui->actionRefresh);
     if(!_ui->archiveListWidget->selectedItems().isEmpty())
     {
@@ -1057,7 +1085,7 @@ void MainWindow::showArchiveListMenu(const QPoint &pos)
 void MainWindow::showJobsListMenu(const QPoint &pos)
 {
     QPoint globalPos = _ui->jobListWidget->viewport()->mapToGlobal(pos);
-    QMenu jobListMenu(_ui->jobListWidget);
+    QMenu  jobListMenu(_ui->jobListWidget);
     if(!_ui->jobListWidget->selectedItems().isEmpty())
     {
         jobListMenu.addAction(_ui->actionJobBackup);
@@ -1085,13 +1113,21 @@ void MainWindow::addDefaultJobs()
             urls << QUrl::fromUserInput(dir.canonicalPath());
             job->setUrls(urls);
             job->setOptionScheduledEnabled(false);
-            job->setOptionPreservePaths(settings.value("tarsnap/preserve_pathnames", true).toBool());
-            job->setOptionTraverseMount(settings.value("tarsnap/traverse_mount", true).toBool());
-            job->setOptionFollowSymLinks(settings.value("tarsnap/follow_symlinks", false).toBool());
-            job->setOptionSkipNoDump(settings.value("app/skip_nodump", false).toBool());
-            job->setOptionSkipFilesSize(settings.value("app/skip_files_size", 0).toULongLong());
-            job->setOptionSkipFiles(settings.value("app/skip_system_enabled", false).toBool());
-            job->setOptionSkipFilesPatterns(settings.value("app/skip_system_files", DEFAULT_SKIP_FILES).toString());
+            job->setOptionPreservePaths(
+                settings.value("tarsnap/preserve_pathnames", true).toBool());
+            job->setOptionTraverseMount(
+                settings.value("tarsnap/traverse_mount", true).toBool());
+            job->setOptionFollowSymLinks(
+                settings.value("tarsnap/follow_symlinks", false).toBool());
+            job->setOptionSkipNoDump(
+                settings.value("app/skip_nodump", false).toBool());
+            job->setOptionSkipFilesSize(
+                settings.value("app/skip_files_size", 0).toULongLong());
+            job->setOptionSkipFiles(
+                settings.value("app/skip_system_enabled", false).toBool());
+            job->setOptionSkipFilesPatterns(
+                settings.value("app/skip_system_files", DEFAULT_SKIP_FILES)
+                    .toString());
             job->save();
             _ui->jobDetailsWidget->jobAdded(job);
         }

--- a/src/widgets/mainwindow.h
+++ b/src/widgets/mainwindow.h
@@ -51,9 +51,9 @@ signals:
 protected:
     void paintEvent(QPaintEvent *);
     void keyReleaseEvent(QKeyEvent *event);
-//    void mousePressEvent(QMouseEvent *event);
-//    void mouseMoveEvent(QMouseEvent *event);
-//    void mouseDoubleClickEvent(QMouseEvent *event);
+    //    void mousePressEvent(QMouseEvent *event);
+    //    void mouseMoveEvent(QMouseEvent *event);
+    //    void mouseDoubleClickEvent(QMouseEvent *event);
 
 public slots:
     void loadSettings();
@@ -65,7 +65,8 @@ public slots:
                                quint64 archiveCount);
     void setTarsnapVersion(QString versionString);
     void notificationRaise();
-    void displayStopTasks(bool backupTaskRunning, int runningTasks, int queuedTasks);
+    void displayStopTasks(bool backupTaskRunning, int runningTasks,
+                          int queuedTasks);
     void tarsnapError(TarsnapError error);
     void appendToJournalLog(LogEntry log);
     void setJournal(QVector<LogEntry> _log);
@@ -97,8 +98,8 @@ private slots:
     void updateAccountCredit(qreal credit, QDate date);
     void updateLastMachineActivity(QStringList activityFields);
     void clearJournalClicked();
-    void showArchiveListMenu(const QPoint& pos);
-    void showJobsListMenu(const QPoint& pos);
+    void showArchiveListMenu(const QPoint &pos);
+    void showJobsListMenu(const QPoint &pos);
     void addDefaultJobs();
 
 private:

--- a/src/widgets/restoredialog.cpp
+++ b/src/widgets/restoredialog.cpp
@@ -24,8 +24,8 @@ RestoreDialog::RestoreDialog(ArchivePtr archive, QWidget *parent)
     // Replace chars that are problematic on common file systems but are allowed
     // in tarsnap archive names
     fileName = fileName.replace(QChar(':'), QChar('-'))
-                       .replace(QChar('/'), QChar('-'))
-                       .replace(QChar('\\'), QChar('-'));
+                   .replace(QChar('/'), QChar('-'))
+                   .replace(QChar('\\'), QChar('-'));
     QFileInfo archiveFile(QDir(_downDir), fileName);
     archiveFile.makeAbsolute();
     _ui->archiveLineEdit->setText(archiveFile.absoluteFilePath());
@@ -33,17 +33,28 @@ RestoreDialog::RestoreDialog(ArchivePtr archive, QWidget *parent)
     _ui->changeArchiveButton->hide();
 
     connect(_ui->cancelButton, &QPushButton::clicked, this, &QDialog::reject);
-    connect(_ui->restoreButton, &QPushButton::clicked, this, [&]()
-    { if(validate()) accept();});
-    connect(_ui->changeDirButton, &QPushButton::clicked, this, &RestoreDialog::changeDir);
-    connect(_ui->changeArchiveButton, &QPushButton::clicked, this, &RestoreDialog::changeArchive);
-    connect(_ui->optionRestoreRadio, &QRadioButton::toggled, this, &RestoreDialog::optionRestoreToggled);
-    connect(_ui->optionBaseDirRadio, &QRadioButton::toggled, this, &RestoreDialog::optionBaseDirToggled);
-    connect(_ui->optionDownArchiveRadio, &QRadioButton::toggled, this, &RestoreDialog::optionDownArchiveToggled);
-    connect(_ui->overwriteCheckBox, &QCheckBox::toggled, this, [&](bool checked)
-    {_ui->keepNewerCheckBox->setChecked(checked);_ui->keepNewerCheckBox->setEnabled(checked);});
-    connect(_ui->baseDirLineEdit, &QLineEdit::textChanged, this, &RestoreDialog::validate);
-    connect(_ui->archiveLineEdit, &QLineEdit::textChanged, this, &RestoreDialog::validate);
+    connect(_ui->restoreButton, &QPushButton::clicked, this, [&]() {
+        if(validate())
+            accept();
+    });
+    connect(_ui->changeDirButton, &QPushButton::clicked, this,
+            &RestoreDialog::changeDir);
+    connect(_ui->changeArchiveButton, &QPushButton::clicked, this,
+            &RestoreDialog::changeArchive);
+    connect(_ui->optionRestoreRadio, &QRadioButton::toggled, this,
+            &RestoreDialog::optionRestoreToggled);
+    connect(_ui->optionBaseDirRadio, &QRadioButton::toggled, this,
+            &RestoreDialog::optionBaseDirToggled);
+    connect(_ui->optionDownArchiveRadio, &QRadioButton::toggled, this,
+            &RestoreDialog::optionDownArchiveToggled);
+    connect(_ui->overwriteCheckBox, &QCheckBox::toggled, this, [&](bool checked) {
+        _ui->keepNewerCheckBox->setChecked(checked);
+        _ui->keepNewerCheckBox->setEnabled(checked);
+    });
+    connect(_ui->baseDirLineEdit, &QLineEdit::textChanged, this,
+            &RestoreDialog::validate);
+    connect(_ui->archiveLineEdit, &QLineEdit::textChanged, this,
+            &RestoreDialog::validate);
 
     if(settings.value("tarsnap/preserve_pathnames", true).toBool())
         _ui->optionRestoreRadio->setChecked(true);
@@ -98,18 +109,19 @@ void RestoreDialog::optionRestoreToggled(bool checked)
 
 void RestoreDialog::changeDir()
 {
-    QString path = QFileDialog::getExistingDirectory(this,
-                   tr("Directory to restore to"), _downDir);
+    QString path =
+        QFileDialog::getExistingDirectory(this, tr("Directory to restore to"),
+                                          _downDir);
     if(!path.isEmpty())
         _ui->baseDirLineEdit->setText(path);
 }
 
 void RestoreDialog::changeArchive()
 {
-    QString path = QFileDialog::getSaveFileName(this,
-                                                tr("Select tar archive file"),
-                                                _ui->archiveLineEdit->text(),
-                                                tr("Tar archives (*.tar)"));
+    QString path =
+        QFileDialog::getSaveFileName(this, tr("Select tar archive file"),
+                                     _ui->archiveLineEdit->text(),
+                                     tr("Tar archives (*.tar)"));
     if(!path.isEmpty())
         _ui->archiveLineEdit->setText(path);
 }
@@ -123,12 +135,14 @@ bool RestoreDialog::validate()
         if(dir.exists() && dir.isDir() && dir.isWritable())
         {
             _ui->baseDirLineEdit->setStyleSheet("QLineEdit{color:black;}");
-            _ui->baseDirLineEdit->setToolTip(tr("Set base directory to extract archive contents to"));
+            _ui->baseDirLineEdit->setToolTip(
+                tr("Set base directory to extract archive contents to"));
         }
         else
         {
             _ui->baseDirLineEdit->setStyleSheet("QLineEdit{color:red;}");
-            _ui->baseDirLineEdit->setToolTip(tr("Invalid base directory. Please choose a different one."));
+            _ui->baseDirLineEdit->setToolTip(
+                tr("Invalid base directory. Please choose a different one."));
             valid = false;
         }
     }
@@ -138,7 +152,8 @@ bool RestoreDialog::validate()
         if(archive.exists())
         {
             _ui->archiveLineEdit->setStyleSheet("QLineEdit{color:red;}");
-            _ui->archiveLineEdit->setToolTip(tr("File exists. Please choose a different file name."));
+            _ui->archiveLineEdit->setToolTip(
+                tr("File exists. Please choose a different file name."));
             valid = false;
         }
         else

--- a/src/widgets/setupdialog.cpp
+++ b/src/widgets/setupdialog.cpp
@@ -316,7 +316,8 @@ void SetupDialog::registerMachine()
             "-" + QDateTime::currentDateTime().toString("yyyy-MM-dd-HH-mm-ss") +
             ".key";
 
-    DEBUG << "Registration details >>\n" << _tarsnapDir << ::endl
+    DEBUG << "Registration details >>\n"
+          << _tarsnapDir << ::endl
           << _appDataDir << ::endl
           << _tarsnapKeyFile << ::endl
           << _tarsnapCacheDir;
@@ -391,12 +392,12 @@ void SetupDialog::commitSettings(bool skipped)
     if(!skipped)
     {
         QSettings settings;
-        settings.setValue("app/app_data",    _appDataDir);
-        settings.setValue("tarsnap/path",    _tarsnapDir);
+        settings.setValue("app/app_data", _appDataDir);
+        settings.setValue("tarsnap/path", _tarsnapDir);
         settings.setValue("tarsnap/version", _tarsnapVersion);
-        settings.setValue("tarsnap/cache",   _tarsnapCacheDir);
-        settings.setValue("tarsnap/key",     _tarsnapKeyFile);
-        settings.setValue("tarsnap/user",    _ui->tarsnapUserLineEdit->text());
+        settings.setValue("tarsnap/cache", _tarsnapCacheDir);
+        settings.setValue("tarsnap/key", _tarsnapKeyFile);
+        settings.setValue("tarsnap/user", _ui->tarsnapUserLineEdit->text());
         settings.setValue("tarsnap/machine", _ui->machineNameLineEdit->text());
     }
     settings.sync();

--- a/src/widgets/textlabel.h
+++ b/src/widgets/textlabel.h
@@ -9,7 +9,7 @@ class TextLabel : public QLabel
     Q_OBJECT
 
     Q_PROPERTY(Qt::TextElideMode elide READ elide WRITE setElide NOTIFY
-               elideChanged DESIGNABLE true)
+                   elideChanged DESIGNABLE true)
     Q_ENUMS(Qt::TextElideMode)
 
 public:


### PR DESCRIPTION
I'm not necessarily advocating that these change be merged; I just wanted to demonstrate what `clang-format` 3.8.0 produces.

I'm personally a huge fan of automatic source-code formatting.  I don't care what that format is; I just want to know that I can run tool X of version Y on a code-base, and end up with a standard format.