### PR TITLE
Console: use fewer dashes

### DIFF
--- a/src/widgets/mainwindow.cpp
+++ b/src/widgets/mainwindow.cpp
@@ -784,7 +784,7 @@ void MainWindow::appendToConsoleLog(const QString &log)
         bf.setBackground(QBrush(qApp->palette().base().color()));
     cursor.mergeBlockFormat(bf);
     cursor.insertText(QString("[%1] %2\n").arg(QDateTime::currentDateTime().toString(Qt::DefaultLocaleShortDate)).arg(log));
-    cursor.insertText(QLatin1String("--------------------------------------------------------------------------------"));
+    cursor.insertText(QLatin1String("----------------------------------------------------------------------------"));
     _ui->consoleLog->moveCursor(QTextCursor::End);
     _ui->consoleLog->ensureCursorVisible();
 }


### PR DESCRIPTION
On Ubuntu 14.04 with the main window as narrow as possible, the "----" lines
overflowed so that there was an entire row of "-------" followed by three
"---" on the next line.