### PR TITLE
Setup: add minimum vsize to title to avoid cutoff

### DIFF
--- a/forms/setupdialog.ui
+++ b/forms/setupdialog.ui
@@ -201,6 +201,9 @@ background-image: url(&quot;:/icons/light-toast.png&quot;);
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
+       <property name="margin">
+        <number>1</number>
+       </property>
       </widget>
      </item>
      <item row="0" column="0" rowspan="2">


### PR DESCRIPTION
Apparently a normal QLabel doesn't "reserve" space for letters which have
parts below the baseline (i.e. "gjpqy") ?!  This commit sets a minimum
vertical space for the setup titles to avoid the bottom portion of "p" and "g"
being cut off.