### PR TITLE
Fix INSTALL instructions for Debian-based distros

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -113,7 +113,7 @@ All of them seem to include the Qt5 SDK in the official main repos.
 1) sudo apt-get install g++ git qtbase5-dev
 2) git clone https://github.com/Tarsnap/tarsnap-gui.git && cd tarsnap-gui
 3) git checkout v0.9 # switch to the desired version
-4) export QT_SELECT=qt5 qmake && make -j$(nproc)
+4) QT_SELECT=qt5 qmake && make -j$(nproc)
 5) ./tarsnap-gui
 
 ---------------------


### PR DESCRIPTION
The `export` is spurious and the command as-is will not work. `QT_SELECT` is only required to run `qmake`, so this changes it so it's only done for the qmake command.