### PR TITLE
Setup: mimic website CSS for "aside" comments

### DIFF
--- a/forms/setupdialog.ui
+++ b/forms/setupdialog.ui
@@ -286,6 +286,16 @@ min-width: 200px;
            <italic>true</italic>
           </font>
          </property>
+         <property name="styleSheet">
+          <string notr="true">QLabel {
+	margin-left: 0.125em;
+	border-width: 0 0 0 0.1em;
+	border-style: solid;
+	border-color: &quot;#999&quot;;
+	color: &quot;#222&quot;;
+	padding-left: 0.25em;
+}</string>
+         </property>
          <property name="text">
           <string>You can also skip this wizard and set up everything inside the application.</string>
          </property>
@@ -387,6 +397,9 @@ min-width: 200px;
         </widget>
        </item>
       </layout>
+      <zorder>welcomePageInfoLabelAside</zorder>
+      <zorder>welcomePageInfoLabel</zorder>
+      <zorder>buttonBox</zorder>
      </widget>
      <widget class="QWidget" name="advancedPage">
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -739,6 +752,16 @@ border: none;
            <italic>true</italic>
           </font>
          </property>
+         <property name="styleSheet">
+          <string notr="true">QLabel {
+	margin-left: 0.125em;
+	border-width: 0 0 0 0.1em;
+	border-style: solid;
+	border-color: &quot;#999&quot;;
+	color: &quot;#222&quot;;
+	padding-left: 0.25em;
+}</string>
+         </property>
          <property name="text">
           <string>If so, you can save time and money by using the same machine key, which allows Tarsnap to access the previously uploaded data.</string>
          </property>
@@ -884,6 +907,16 @@ border: none;
           <font>
            <italic>true</italic>
           </font>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QLabel {
+	margin-left: 0.125em;
+	border-width: 0 0 0 0.1em;
+	border-style: solid;
+	border-color: &quot;#999&quot;;
+	color: &quot;#222&quot;;
+	padding-left: 0.25em;
+}</string>
          </property>
          <property name="text">
           <string>Don't have an account? Register on &lt;a href=&quot;http://tarsnap.com&quot;&gt;tarsnap.com&lt;/a&gt;, then come back.</string>


### PR DESCRIPTION
I think it might be nice to imitate the way the Tarsnap website handles `<aside>` comments:
http://www.tarsnap.com/

This re-adds the left margins that were removed in a61e2e5, and adds a `border-left` to add more visual emphasis that this is a different type of comment than the plain text.

![gui-aside-2](https://cloud.githubusercontent.com/assets/222157/15127831/3fb5d702-15ed-11e6-84cb-8a07cc82a06c.png)

