### PR TITLE
Setup: remove text color from "aside" comments

### DIFF
--- a/forms/setupdialog.ui
+++ b/forms/setupdialog.ui
@@ -292,7 +292,6 @@ min-width: 200px;
 	border-width: 0 0 0 0.1em;
 	border-style: solid;
 	border-color: &quot;#999&quot;;
-	color: &quot;#222&quot;;
 	padding-left: 0.25em;
 }</string>
          </property>
@@ -758,7 +757,6 @@ border: none;
 	border-width: 0 0 0 0.1em;
 	border-style: solid;
 	border-color: &quot;#999&quot;;
-	color: &quot;#222&quot;;
 	padding-left: 0.25em;
 }</string>
          </property>
@@ -914,7 +912,6 @@ border: none;
 	border-width: 0 0 0 0.1em;
 	border-style: solid;
 	border-color: &quot;#999&quot;;
-	color: &quot;#222&quot;;
 	padding-left: 0.25em;
 }</string>
          </property>


### PR DESCRIPTION
The "faded" text color turned out to be darker than the default text on Ubuntu
14.04, so I removed the color change.  I didn't realize that different systems
have different default text colors.

Details are as follows.  On my main system (icewm), adding:

    qDebug() <<
        _ui->welcomePageInfoLabel->palette().color(
            QPalette::WindowText);

shows that it's black:

    src/widgets/setupdialog.cpp(111): QColor(ARGB 1, 0, 0, 0)

However, on Ubuntu 14.04 with the default UI, I see:

    src/widgets/setupdialog.cpp(111): QColor(ARGB 1, 0.298039, 0.298039, 0.298039)