### PR TITLE
Remove compiler warning about an unused variable

### DIFF
--- a/src/widgets/mainwindow.cpp
+++ b/src/widgets/mainwindow.cpp
@@ -1106,9 +1106,8 @@ void MainWindow::displayStopTasks(bool backupTaskRunning, int runningTasks,
     QPushButton *stopAll = nullptr;
     if(runningTasks || queuedTasks)
         stopAll = msgBox.addButton(tr("Stop all"), QMessageBox::ActionRole);
-    QPushButton *background = nullptr;
     if((runningTasks || queuedTasks) && _aboutToQuit)
-        background = msgBox.addButton(tr("Proceed in background"), QMessageBox::ActionRole);
+        msgBox.addButton(tr("Proceed in background"), QMessageBox::ActionRole);
     QPushButton *cancel = msgBox.addButton(QMessageBox::Cancel);
     msgBox.setDefaultButton(cancel);
     msgBox.exec();


### PR DESCRIPTION
The "background" variable wasn't being used, and it doesn't seem to be
necessary to check for it in the "if" statments (lower in the function).