### PR TITLE
Remove QKeySequence::Cancel

### DIFF
--- a/src/widgets/archivewidget.cpp
+++ b/src/widgets/archivewidget.cpp
@@ -9,9 +9,10 @@ ArchiveWidget::ArchiveWidget(QWidget *parent)
     QSettings settings;
     _useIECPrefixes = settings.value("app/iec_prefixes", false).toBool();
 
-    _ui.hideButton->setToolTip(_ui.hideButton->toolTip()
-                               .arg(QKeySequence(QKeySequence::Cancel)
-                                    .toString(QKeySequence::NativeText)));
+    // Requires Qt 5.6 or higher to build!
+    //_ui.hideButton->setToolTip(_ui.hideButton->toolTip()
+    //                           .arg(QKeySequence(QKeySequence::Cancel)
+    //                                .toString(QKeySequence::NativeText)));
 
     connect(_ui.hideButton, &QPushButton::clicked, this, &ArchiveWidget::hide);
     connect(_ui.archiveJobLabel, &TextLabel::clicked,

--- a/src/widgets/jobwidget.cpp
+++ b/src/widgets/jobwidget.cpp
@@ -11,9 +11,10 @@ JobWidget::JobWidget(QWidget *parent)
 {
     _ui.setupUi(this);
     _ui.archiveListWidget->setAttribute(Qt::WA_MacShowFocusRect, false);
-    _ui.hideButton->setToolTip(_ui.hideButton->toolTip()
-                               .arg(QKeySequence(QKeySequence::Cancel)
-                                    .toString(QKeySequence::NativeText)));
+    // Requires Qt 5.6 or higher to build!
+    //_ui.hideButton->setToolTip(_ui.hideButton->toolTip()
+    //                           .arg(QKeySequence(QKeySequence::Cancel)
+    //                                .toString(QKeySequence::NativeText)));
     _ui.infoLabel->hide();
     _fsEventUpdate.setSingleShot(true);
     connect(&_fsEventUpdate, &QTimer::timeout, this, &JobWidget::verifyJob);


### PR DESCRIPTION
This was added in Qt 5.6.0, and does not compile on earlier versions.