### PR TITLE
Allow optional whitespace in Tarsnap version regex

### DIFF
--- a/src/taskmanager.cpp
+++ b/src/taskmanager.cpp
@@ -1144,7 +1144,7 @@ void TaskManager::getTarsnapVersionFinished(QVariant data, int exitCode,
         return;
     }
 
-    QRegExp versionRx("^tarsnap (\\S+)\\s$");
+    QRegExp versionRx("^tarsnap (\\S+)\\s?$");
     if(-1 != versionRx.indexIn(output))
         emit tarsnapVersion(versionRx.cap(1));
 }


### PR DESCRIPTION
The recent commit b6dfb04b418499e58ce5b56527566037c15c289f added a `.trimmed()` to the command-line output, so the previous regex failed to find the version string.