### PR TITLE
JobListWidgetItem: add delete to UI

### DIFF
--- a/forms/joblistwidgetitem.ui
+++ b/forms/joblistwidgetitem.ui
@@ -120,6 +120,53 @@ font-size: 11px;
     </widget>
    </item>
    <item>
+    <widget class="QToolButton" name="backupButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>27</width>
+       <height>27</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>27</width>
+       <height>27</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Initiate a backup for this Job &lt;span style=&quot;color:gray;font-size:small&quot;&gt;%1&lt;/span&gt;</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QToolButton {
+border: none;
+border-radius: 4px;
+}
+
+QToolButton:hover {
+background: rgba(179, 190, 255, 120);
+}
+
+QToolButton:pressed {
+padding-top: 2px;
+padding-left: 2px;
+}</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="../resources/resources.qrc">
+       <normaloff>:/icons/tarsnap-icon.png</normaloff>:/icons/tarsnap-icon.png</iconset>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QToolButton" name="inspectButton">
      <property name="minimumSize">
       <size>
@@ -202,13 +249,7 @@ padding-left: 2px;
     </widget>
    </item>
    <item>
-    <widget class="QToolButton" name="backupButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+    <widget class="QToolButton" name="deleteButton">
      <property name="minimumSize">
       <size>
        <width>27</width>
@@ -222,7 +263,7 @@ padding-left: 2px;
       </size>
      </property>
      <property name="toolTip">
-      <string>Initiate a backup for this Job &lt;span style=&quot;color:gray;font-size:small&quot;&gt;%1&lt;/span&gt;</string>
+      <string>Delete this Job &lt;span style=&quot;color:gray;font-size:small&quot;&gt;%1&lt;/span&gt;</string>
      </property>
      <property name="styleSheet">
       <string notr="true">QToolButton {
@@ -244,7 +285,7 @@ padding-left: 2px;
      </property>
      <property name="icon">
       <iconset resource="../resources/resources.qrc">
-       <normaloff>:/icons/tarsnap-icon.png</normaloff>:/icons/tarsnap-icon.png</iconset>
+       <normaloff>:/icons/trash.png</normaloff>:/icons/trash.png</iconset>
      </property>
     </widget>
    </item>
@@ -292,6 +333,21 @@ padding-left: 2px;
    </property>
    <property name="shortcut">
     <string>Ctrl+B</string>
+   </property>
+  </action>
+  <action name="actionDelete">
+   <property name="icon">
+    <iconset resource="../resources/resources.qrc">
+     <normaloff>:/icons/trash.png</normaloff>:/icons/trash.png</iconset>
+   </property>
+   <property name="text">
+    <string>Delete</string>
+   </property>
+   <property name="toolTip">
+    <string>Delete jobs(s)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+D</string>
    </property>
   </action>
  </widget>

--- a/src/widgets/joblistwidgetitem.cpp
+++ b/src/widgets/joblistwidgetitem.cpp
@@ -16,6 +16,9 @@ JobListWidgetItem::JobListWidgetItem(JobPtr job)
     _ui.backupButton->setToolTip(_ui.backupButton->toolTip()
                                    .arg(_ui.actionJobBackup->shortcut()
                                         .toString(QKeySequence::NativeText)));
+    _ui.deleteButton->setToolTip(_ui.deleteButton->toolTip()
+                                   .arg(_ui.actionDelete->shortcut()
+                                        .toString(QKeySequence::NativeText)));
 
     connect(_ui.backupButton, &QToolButton::clicked, this,
             &JobListWidgetItem::requestBackup);
@@ -23,6 +26,8 @@ JobListWidgetItem::JobListWidgetItem(JobPtr job)
             &JobListWidgetItem::requestInspect);
     connect(_ui.restoreButton, &QToolButton::clicked, this,
             &JobListWidgetItem::requestRestore);
+    connect(_ui.deleteButton, &QToolButton::clicked, this,
+            &JobListWidgetItem::requestDelete);
 
     setJob(job);
 }


### PR DESCRIPTION
This increases consistency in the app:
- in the Backup list, the right-most is "remove this file/dir"
- in the Archive list, the right-most is delete
- right-clicking in the Jobs list shows Backup, Info, Restore, Delete.

Moving the Backup icon to the left position (in the right-most block of icons) and adding a Delete icon to the right makes the icons match the right-click menu.