### PR TITLE
Display copy&pasteable commands

### DIFF
--- a/src/tarsnaptask.cpp
+++ b/src/tarsnaptask.cpp
@@ -1,4 +1,5 @@
 #include "tarsnaptask.h"
+#include "utils.h"
 #include "debug.h"
 
 #if defined Q_OS_UNIX
@@ -28,7 +29,7 @@ void TarsnapTask::run()
     _process->setArguments(_arguments);
     LOG << tr("Executing command:\n[%1 %2]")
                .arg(_process->program())
-               .arg(_process->arguments().join(' '));
+               .arg(Utils::quoteCommandLine(_process->arguments()));
     _process->start();
     if(_process->waitForStarted(DEFAULT_TIMEOUT_MS))
     {
@@ -174,7 +175,7 @@ void TarsnapTask::processFinished()
             }
             LOG << tr("Command finished with exit code %3 and output:\n[%1 %2]\n%4")
                        .arg(_command)
-                       .arg(_arguments.join(' '))
+                       .arg(Utils::quoteCommandLine(_arguments))
                        .arg(_process->exitCode())
                        .arg(output);
         }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -149,3 +149,24 @@ bool Utils::tarsnapVersionMinimum(const QString &minVersion)
     return (-1 != versionRx.indexIn(tarsnapVersion)) &&
            (versionRx.cap(0) >= minVersion);
 }
+
+QString Utils::quoteCommandLine(QStringList args)
+{
+    QStringList escaped;
+    QRegExp rx("^[0-9a-z-A-Z/._-]*$");
+    QString cmdLine;
+
+    for (int i = 0; i < args.size(); ++i) {
+        QString arg = args.at(i);
+        if (rx.indexIn(arg) >= 0) {
+            escaped.append(arg);
+        } else {
+            escaped.append(arg.prepend("\'").append("\'"));
+        }
+    }
+
+    cmdLine = escaped.join(' ');
+    return (cmdLine);
+}
+
+

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,6 +3,7 @@
 
 #include <QDir>
 #include <QRunnable>
+#include <QStringList>
 
 #define CMD_TARSNAP         "tarsnap"
 #define CMD_TARSNAPKEYGEN   "tarsnap-keygen"
@@ -92,6 +93,8 @@ QString validateAppDataDir(QString path);
 // Verifies if the current CLI utils version is at least minVersion
 bool tarsnapVersionMinimum(const QString &minVersion);
 
+// Displays a "copy&paste-able" command line.
+QString quoteCommandLine(QStringList args);
 } // namespace Utils
 
 #endif // UTILS_H


### PR DESCRIPTION
The previous commands would fail if a directory contained a space (for example, with the default ".../Tarsnap Backup Inc./..."). QProcess automatically escapes spaces in arguments before it runs
a command, but unbelievably there is no way to access the "escaped" arguments.  (QProcess.arguments() returns the un-escaped strings)

Adding double-quotes around each argument seems like a safer solution than trying to escape spaces.  I admit it that it looks weird to see things like

    /usr/bin/tarsnap "--version"

but I think that's an acceptable sacrifice (although clearly not ideal!).

NOTE: the actual command that QProcess runs is *not* changed by this commit.  This commit only changes what is displayed on the command-line and console log.