### PR TITLE
ArchiveWidget: remove "custom" from doxygen

### DIFF
--- a/src/widgets/archivewidget.h
+++ b/src/widgets/archivewidget.h
@@ -10,7 +10,7 @@
 
 /*!
  * \ingroup widgets-specialized
- * \brief The ArchiveWidget is a custom QWidget which displays detailed
+ * \brief The ArchiveWidget is a QWidget which displays detailed
  * information about a single Archive.
  */
 class ArchiveWidget : public QWidget


### PR DESCRIPTION
We haven't used the term "custom" to describe any of the other subclassed Qt objects; I think that's implied.
