### PR TITLE
Check for Qt 5.2 or higher

### DIFF
--- a/Tarsnap.pro
+++ b/Tarsnap.pro
@@ -1,5 +1,5 @@
-# Check for at least Qt 5
-lessThan(QT_MAJOR_VERSION, 5): error("Tarsnap-gui requires Qt 5 or higher.")
+# Check for at least Qt 5.2
+lessThan(QT_VERSION, 5.2): error("Tarsnap-gui requires Qt 5.2 or higher.")
 
 QT += core gui network sql widgets
 CONFIG += c++11


### PR DESCRIPTION
We use QLineEdit->setClearButtonEnabled(), which was introduced in 5.2:
http://doc.qt.io/qt-5/qlineedit.html#clearButtonEnabled-prop