### PR TITLE
Set a minimum height (for small displays)

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -60,6 +60,12 @@
          <enum>Qt::Vertical</enum>
         </property>
         <widget class="QTabWidget" name="mainTabWidget">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>350</height>
+          </size>
+         </property>
          <property name="focusPolicy">
           <enum>Qt::NoFocus</enum>
          </property>


### PR DESCRIPTION
Without a minimum height on mainTabWidget, Qt uses the sizeHint as the minimum
sizes, and we end up with a main display that can't be shorter than 603 pixels.

For reference, the default Ubuntu 14.04 GUI (on a 640x480 screen) allows up to
456 pixels high for a maximized window, or 428 for a non-maximized one.