### PR TITLE
RestoreDialog: don't display if file list if not available

### DIFF
--- a/src/widgets/restoredialog.cpp
+++ b/src/widgets/restoredialog.cpp
@@ -58,8 +58,16 @@ RestoreDialog::RestoreDialog(QWidget *parent, ArchivePtr archive, QStringList fi
     _ui.optionBaseDirRadio->setChecked(!canRestore);
     if(!_files.isEmpty())
         _ui.filesListWidget->addItems(_files);
-    else
-        _ui.filesListWidget->addItems(_archive->contents().split(QChar('\n')));
+    else {
+        if(_archive->contents().isEmpty()) {
+            _ui.filesListWidget->hide();
+            adjustSize();
+        } else {
+            _ui.filesListWidget->addItems(_archive->contents().split(QChar('\n')));
+            _ui.filesListWidget->show();
+            adjustSize();
+        }
+    }
 }
 
 RestoreDialog::~RestoreDialog()


### PR DESCRIPTION
This only applies when restoring an entire archive.