### PR TITLE
Avoid MainWindow logo overlapping the "Help" tab.

### DIFF
--- a/src/widgets/mainwindow.cpp
+++ b/src/widgets/mainwindow.cpp
@@ -555,8 +555,12 @@ void MainWindow::paintEvent(QPaintEvent *)
     opt.init(this);
     QPainter p(this);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
+    // Find out how much room is left to display an icon, including a
+    // "fudge factor" to accommodate margins.
+    int remaining_width = frameGeometry().width() - minimumWidth() + 8;
 
-    if(frameGeometry().width() > 460)
+    // Compare with the width of the png files.
+    if(remaining_width > 131)
     {
         QPixmap pixmap(":/icons/tarsnap-logo.png");
         QIcon   icon;
@@ -564,7 +568,7 @@ void MainWindow::paintEvent(QPaintEvent *)
         icon.paint(&p, width() - pixmap.width() - 5, 3, pixmap.width(),
                    pixmap.height());
     }
-    else if(frameGeometry().width() > 360)
+    else if(remaining_width > 29)
     {
         QPixmap pixmap(":/icons/tarsnap-logo-icon.png");
         QIcon   icon;


### PR DESCRIPTION
This might be an issue of window manager and/or Qt version, but the previous
version could have the logo (partly) hiding behind the "Help" tab.  This
change:
- compares a "remaining width" against the width in of the actual png files,
  so it's easier to see what's happening.
- condenses the "fudge factor" to a single +8 that's applied to this value.
  If we discover more problems with this spacing, we'll have a single place
  to investigate.