### PR TITLE
Rename MainWindow::displayStopTasks to displayStopTasksDialog

### DIFF
--- a/src/coreapplication.cpp
+++ b/src/coreapplication.cpp
@@ -207,7 +207,7 @@ void CoreApplication::showMainWindow()
     connect(_mainWindow, &MainWindow::getTaskInfo, &_taskManager,
             &TaskManager::getTaskInfo, QUEUED);
     connect(&_taskManager, &TaskManager::taskInfo, _mainWindow,
-            &MainWindow::displayStopTasks, QUEUED);
+            &MainWindow::displayStopTasksDialog, QUEUED);
     connect(_mainWindow, &MainWindow::jobAdded, &_taskManager,
             &TaskManager::addJob, QUEUED);
     connect(_mainWindow, &MainWindow::getKeyId, &_taskManager,

--- a/src/widgets/mainwindow.cpp
+++ b/src/widgets/mainwindow.cpp
@@ -1690,7 +1690,7 @@ void MainWindow::addJobClicked()
     }
 }
 
-void MainWindow::displayStopTasks(bool backupTaskRunning, int runningTasks,
+void MainWindow::displayStopTasksDialog(bool backupTaskRunning, int runningTasks,
                                   int queuedTasks)
 {
     if(!runningTasks && !queuedTasks)

--- a/src/widgets/mainwindow.h
+++ b/src/widgets/mainwindow.h
@@ -43,10 +43,11 @@ public slots:
     //! Update the Tarsnap version number, and store it in the settings.
     void updateTarsnapVersion(QString versionString);
     void notificationRaise();
-    //! Display stop tasks dialog. Also used when quitting the application 
-    //! while active or background tasks are queued.
-    void displayStopTasks(bool backupTaskRunning, int runningTasks,
-                          int queuedTasks);
+    //! Prompt user to clarify whether to stop background tasks; if so,
+    //! quits the app. Also used when quitting the application while active
+    //! or background tasks are queued.
+    void displayStopTasksDialog(bool backupTaskRunning, int runningTasks,
+                                int queuedTasks);
     //! Display an explanation of a tarsnap CLI error.
     void tarsnapError(TarsnapError error);
     //! Append a new entry to the journal.
@@ -88,8 +89,8 @@ signals:
     //! Begin tarsnap --version
     void getTarsnapVersion(QString tarsnapPath);
     void displayNotification(QString message);
-    //! Query whether there are any running tasks; will receive a taskInfo
-    //! signal which is received by \ref displayStopTasks.
+    //! Query whether there are any running tasks; will trigger a taskInfo
+    //! signal which is received by \ref displayStopTasksDialog.
     void getTaskInfo();
     void jobAdded(JobPtr job);
     //! Clear all Journal entries.


### PR DESCRIPTION
I was quite confused about the original name; I think that appending "Dialog"
will help a lot.

I also revised the doxygen comment: I think it's important to specify that this
function is responsible for actually quitting the app.  Longer-term, I might
propose some kind of refactoring to the app quitting logic to avoid having the
->quit() inside a "Dialog" function, but right now, I think the priority should
be clarifying what's currently happening.