### PR TITLE
Only display one "About" window at once

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -2320,6 +2320,9 @@ border-top: 2px groove darkgrey;
                  <property name="text">
                   <string>About Tarsnap</string>
                  </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
                 </widget>
                </item>
               </layout>

--- a/src/widgets/mainwindow.h
+++ b/src/widgets/mainwindow.h
@@ -59,6 +59,8 @@ public slots:
     void saveKeyId(QString key, int id);
     //! Create a new archive from an existing Job.
     void backupJob(JobPtr job);
+    //! The "About" window was closed.
+    void showAboutClosed(int result);
 
 signals:
     //! Begin tarsnap -c -f \<name\>
@@ -140,7 +142,7 @@ private slots:
     void showJobsListMenu(const QPoint &pos);
     void addDefaultJobs();
     void createJobClicked();
-    void showAbout();
+    void aboutButtonClicked();
     void mainTabChanged(int index);
     void validateBackupTab();
     void enableJobScheduling();
@@ -157,6 +159,7 @@ private:
     TarsnapAccount _tarsnapAccount;
     bool           _aboutToQuit;
     QString        _helpTabHTML;
+    QDialog        _aboutWindow;
 
     void updateUi();
 };


### PR DESCRIPTION
Without this patch, a user could click on "About Tarsnap" multiple times,
generating a window each time.