### PR TITLE
Improve startup sequence for automatic sched. backup.

### DIFF
--- a/src/taskmanager.h
+++ b/src/taskmanager.h
@@ -16,6 +16,8 @@
 #include <QThreadPool>
 #include <QUrl>
 #include <QUuid>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
 
 /*!
  * \ingroup background-tasks
@@ -151,6 +153,8 @@ private slots:
     void startTask(TarsnapTask *task);
     void dequeueTask();
 
+    void executeScheduledJobs();
+
 private:
     void parseError(QString tarsnapOutput);
     void parseGlobalStats(QString tarsnapOutput);
@@ -158,6 +162,7 @@ private:
                            ArchivePtr archive);
     QString makeTarsnapCommand(QString cmd);
     void initTarsnapArgs(QStringList &args);
+    QNetworkReply* tarsnapHeadRequest(QString url);
 
     QMap<QUuid, BackupTaskPtr> _backupTaskMap;
     QMap<QString, ArchivePtr>  _archiveMap;
@@ -165,6 +170,7 @@ private:
     QQueue<TarsnapTask *> _taskQueue; // mutually exclusive tasks
     QThreadPool *         _threadPool;
     QMap<QString, JobPtr> _jobMap;
+    QNetworkAccessManager _nam;
 };
 
 #endif // TASKMANAGER_H


### PR DESCRIPTION
Check for Tarsnap servers reachability before starting a backup
and if not reachable allow for an extra 30 seconds before trying
again and then finally quitting with an explicit message (log and
system notification) of why the backup has not proceeded.

Trying to backup as soon as the system wakes up is not graceful
enough to account for wifi autojoin or other cases of system load,
thus many backup failures.