### PR TITLE
tarsnapaccount.cpp: include QHeaderView for Qt 5.11.0 compatibility

### DIFF
--- a/src/tarsnapaccount.cpp
+++ b/src/tarsnapaccount.cpp
@@ -2,6 +2,7 @@
 #include "debug.h"
 #include "utils.h"
 
+#include <QHeaderView>
 #include <QMessageBox>
 #include <QNetworkReply>
 #include <QNetworkRequest>


### PR DESCRIPTION
Fixes https://github.com/Tarsnap/tarsnap-gui/issues/179