### PR TITLE
The homebrew/gui tap is empty and deprecated

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,9 +11,7 @@ OS X
 Tarsnap GUI can be easily installed on OS X via the Homebrew package manager:
 
 1) Install Homebrew from https://brew.sh
-2) Tap Homebrew-gui repo:
-$brew tap homebrew/gui
-3) To install tarsnap-gui (including all dependencies) run this in Terminal:
+2) To install tarsnap-gui (including all dependencies) run this in Terminal:
 $brew install tarsnap-gui && brew linkapps tarsnap-gui
 
 Tarsnap.app bundle has been linked into /Applications. Homebrew installs the


### PR DESCRIPTION
Step 2 is now unnecessary. If you run that command, you get the following message from `brew`:

> Error: homebrew/gui was deprecated. This tap is now empty as all its formulae were migrated.

Everyone can now `brew install tarsnap-gui` directly.