### PR TITLE
Fix updating existing jobs

### DIFF
--- a/src/persistentmodel/job.cpp
+++ b/src/persistentmodel/job.cpp
@@ -275,7 +275,7 @@ void Job::save()
             "optionTraverseMount=?, optionFollowSymLinks=?, "
             "optionSkipFilesSize=?, "
             "optionSkipFiles=?, optionSkipFilesPatterns=?, optionSkipNoDump=?, "
-            "settingShowHidden=?, settingShowSystem=?, settingHideSymlinks=?"
+            "settingShowHidden=?, settingShowSystem=?, settingHideSymlinks=? "
             "where name=?");
     else
         queryString = QLatin1String(


### PR DESCRIPTION
There was a syntax error in the `update jobs` SQL statement, preventing users from modifying values for existing jobs. (E.g. changing a job's update schedule from Disabled to Daily.)
