### PR TITLE
Fix missing Tarsnap command-line utilities

### DIFF
--- a/src/widgets/setupdialog.cpp
+++ b/src/widgets/setupdialog.cpp
@@ -21,6 +21,8 @@ SetupDialog::SetupDialog(QWidget *parent)
     // validateAdvancedSetupPage() to avoid calling that function
     // unnecessarily.
     _tarsnapDir = Utils::findTarsnapClientInPath("", true);
+    if (_tarsnapDir == "")
+      _tarsnapDir = "/usr/local/bin";
     _ui.tarsnapPathLineEdit->setText(_tarsnapDir);
     _ui.machineNameLineEdit->setText(QHostInfo::localHostName());
     _ui.wizardStackedWidget->setCurrentWidget(_ui.welcomePage);


### PR DESCRIPTION
Closes #168

I'm not absolutely certain this will fix #168, but I'm reasonably
certain.

I ran into the bug again tonight on a clean macOS laptop. The core
issue seems to be that this line is returning an empty string for
fresh installations of Tarsnap:

```
_tarsnapDir = Utils::findTarsnapClientInPath("", true);
```

Rather than hunt down why it's empty, I just fall back to
`/usr/local/bin` if it is.